### PR TITLE
Implement a class to manage the tilemap

### DIFF
--- a/src/scenes/PlayScene.ts
+++ b/src/scenes/PlayScene.ts
@@ -1,5 +1,4 @@
 import Phaser from "phaser";
-import TextureGenerator from "../utils/TextureGenerator";
 import TilemapManager from "../utils/TilemapManager";
 
 class PlayScene extends Phaser.Scene {
@@ -14,6 +13,7 @@ class PlayScene extends Phaser.Scene {
 	create() {
 		const tilemapManager = new TilemapManager(this);
 		tilemapManager.setTile(2, 2, true); // Example usage
+		tilemapManager.setTile(3, 3, false); // Exaeple usage
 	}
 
 	update() {

--- a/src/scenes/PlayScene.ts
+++ b/src/scenes/PlayScene.ts
@@ -1,5 +1,6 @@
 import Phaser from "phaser";
 import TextureGenerator from "../utils/TextureGenerator";
+import TilemapManager from "../utils/TilemapManager";
 
 class PlayScene extends Phaser.Scene {
 	constructor() {
@@ -10,7 +11,10 @@ class PlayScene extends Phaser.Scene {
 		// Load assets here
 	}
 
-	create() {}
+	create() {
+		const tilemapManager = new TilemapManager(this);
+		tilemapManager.setTile(2, 2, true); // Example usage
+	}
 
 	update() {
 		// Update game objects here

--- a/src/utils/TextureGenerator.ts
+++ b/src/utils/TextureGenerator.ts
@@ -1,16 +1,20 @@
 import Phaser from "phaser";
 
 class TextureGenerator {
-  static generateTexture(scene: Phaser.Scene, color: number, width: number, height: number, name: string) {
-    const graphics = scene.add.graphics();
-    graphics.fillStyle(color, 1);
-    graphics.fillRect(0, 0, width, height);
+	static generateTexture(
+		scene: Phaser.Scene,
+		color: number,
+		width: number,
+		height: number,
+		name: string,
+	) {
+		const graphics = scene.add.graphics();
+		graphics.fillStyle(color, 1);
+		graphics.fillRect(0, 0, width, height);
 
-    const texture = graphics.generateTexture(name, width, height);
-    graphics.destroy();
-
-    return texture;
-  }
+		graphics.generateTexture(name, width, height);
+		graphics.destroy();
+	}
 }
 
 export default TextureGenerator;

--- a/src/utils/TilemapManager.ts
+++ b/src/utils/TilemapManager.ts
@@ -2,37 +2,67 @@ import Phaser from "phaser";
 import TextureGenerator from "./TextureGenerator";
 
 class TilemapManager {
-  private scene: Phaser.Scene;
-  private tilemap: Phaser.Tilemaps.Tilemap;
-  private emptyTileset: Phaser.Tilemaps.Tileset;
-  private filledTileset: Phaser.Tilemaps.Tileset;
-  private layer: Phaser.Tilemaps.TilemapLayer;
+	private scene: Phaser.Scene;
+	private tilemap: Phaser.Tilemaps.Tilemap;
+	private emptyTileset: Phaser.Tilemaps.Tileset;
+	private filledTileset: Phaser.Tilemaps.Tileset;
+	private layer: Phaser.Tilemaps.TilemapLayer;
 
-  constructor(scene: Phaser.Scene) {
-    this.scene = scene;
-    this.createTilemap();
-  }
+	constructor(scene: Phaser.Scene) {
+		this.scene = scene;
+		this.createTilemap();
+	}
 
-  private createTilemap() {
-    const emptyTexture = TextureGenerator.generateTexture(this.scene, 0xffffff, 32, 32, "empty");
-    const filledTexture = TextureGenerator.generateTexture(this.scene, 0x000000, 32, 32, "filled");
+	private createTilemap() {
+		TextureGenerator.generateTexture(this.scene, 0xff00ff, 32, 32, "empty");
+		TextureGenerator.generateTexture(this.scene, 0x00ff00, 32, 32, "filled");
 
-    this.tilemap = this.scene.make.tilemap({ width: 10, height: 10, tileWidth: 32, tileHeight: 32 });
-    this.emptyTileset = this.tilemap.addTilesetImage("empty", emptyTexture);
-    this.filledTileset = this.tilemap.addTilesetImage("filled", filledTexture);
-    this.layer = this.tilemap.createBlankLayer("layer", [this.emptyTileset, this.filledTileset]);
+		this.tilemap = this.scene.make.tilemap({
+			width: 10,
+			height: 10,
+			tileWidth: 32,
+			tileHeight: 32,
+		});
+		this.filledTileset = this.tilemap.addTilesetImage(
+			"filled",
+			undefined,
+			32,
+			32,
+			0,
+			0,
+			1,
+		);
 
-    this.setupCollision();
-  }
+		this.emptyTileset = this.tilemap.addTilesetImage(
+			"empty",
+			undefined,
+			32,
+			32,
+			0,
+			0,
+			2,
+		);
+		this.layer = this.tilemap.createBlankLayer("layer", [
+			this.emptyTileset,
+			this.filledTileset,
+		]);
 
-  private setupCollision() {
-    this.layer.setCollisionBetween(this.filledTileset.firstgid, this.filledTileset.firstgid);
-  }
+		this.setupCollision();
+	}
 
-  public setTile(x: number, y: number, filled: boolean) {
-    const tileIndex = filled ? this.filledTileset.firstgid : this.emptyTileset.firstgid;
-    this.tilemap.putTileAt(tileIndex, x, y, true, this.layer);
-  }
+	private setupCollision() {
+		this.layer.setCollisionBetween(
+			this.filledTileset.firstgid,
+			this.filledTileset.firstgid,
+		);
+	}
+
+	public setTile(x: number, y: number, filled: boolean) {
+		const tileIndex = filled
+			? this.filledTileset.firstgid
+			: this.emptyTileset.firstgid;
+		this.tilemap.putTileAt(tileIndex, x, y, true, this.layer);
+	}
 }
 
 export default TilemapManager;

--- a/src/utils/TilemapManager.ts
+++ b/src/utils/TilemapManager.ts
@@ -1,0 +1,36 @@
+import Phaser from "phaser";
+import TextureGenerator from "./TextureGenerator";
+
+class TilemapManager {
+  private scene: Phaser.Scene;
+  private tilemap: Phaser.Tilemaps.Tilemap;
+  private tileset: Phaser.Tilemaps.Tileset;
+  private layer: Phaser.Tilemaps.TilemapLayer;
+
+  constructor(scene: Phaser.Scene) {
+    this.scene = scene;
+    this.createTilemap();
+  }
+
+  private createTilemap() {
+    const emptyTexture = TextureGenerator.generateTexture(this.scene, 0xffffff, 32, 32, "empty");
+    const filledTexture = TextureGenerator.generateTexture(this.scene, 0x000000, 32, 32, "filled");
+
+    this.tilemap = this.scene.make.tilemap({ width: 10, height: 10, tileWidth: 32, tileHeight: 32 });
+    this.tileset = this.tilemap.addTilesetImage("tiles", null, 32, 32, 0, 0, [emptyTexture, filledTexture]);
+    this.layer = this.tilemap.createBlankLayer("layer", this.tileset);
+
+    this.setupCollision();
+  }
+
+  private setupCollision() {
+    this.layer.setCollisionBetween(1, 1);
+  }
+
+  public setTile(x: number, y: number, filled: boolean) {
+    const tileIndex = filled ? 1 : 0;
+    this.tilemap.putTileAt(tileIndex, x, y, true, this.layer);
+  }
+}
+
+export default TilemapManager;

--- a/src/utils/TilemapManager.ts
+++ b/src/utils/TilemapManager.ts
@@ -4,7 +4,8 @@ import TextureGenerator from "./TextureGenerator";
 class TilemapManager {
   private scene: Phaser.Scene;
   private tilemap: Phaser.Tilemaps.Tilemap;
-  private tileset: Phaser.Tilemaps.Tileset;
+  private emptyTileset: Phaser.Tilemaps.Tileset;
+  private filledTileset: Phaser.Tilemaps.Tileset;
   private layer: Phaser.Tilemaps.TilemapLayer;
 
   constructor(scene: Phaser.Scene) {
@@ -17,18 +18,19 @@ class TilemapManager {
     const filledTexture = TextureGenerator.generateTexture(this.scene, 0x000000, 32, 32, "filled");
 
     this.tilemap = this.scene.make.tilemap({ width: 10, height: 10, tileWidth: 32, tileHeight: 32 });
-    this.tileset = this.tilemap.addTilesetImage("tiles", null, 32, 32, 0, 0, [emptyTexture, filledTexture]);
-    this.layer = this.tilemap.createBlankLayer("layer", this.tileset);
+    this.emptyTileset = this.tilemap.addTilesetImage("empty", emptyTexture);
+    this.filledTileset = this.tilemap.addTilesetImage("filled", filledTexture);
+    this.layer = this.tilemap.createBlankLayer("layer", [this.emptyTileset, this.filledTileset]);
 
     this.setupCollision();
   }
 
   private setupCollision() {
-    this.layer.setCollisionBetween(1, 1);
+    this.layer.setCollisionBetween(this.filledTileset.firstgid, this.filledTileset.firstgid);
   }
 
   public setTile(x: number, y: number, filled: boolean) {
-    const tileIndex = filled ? 1 : 0;
+    const tileIndex = filled ? this.filledTileset.firstgid : this.emptyTileset.firstgid;
     this.tilemap.putTileAt(tileIndex, x, y, true, this.layer);
   }
 }


### PR DESCRIPTION
Related to #13

Add a `TilemapManager` class to manage the tilemap and update `PlayScene` to use it.

* **TilemapManager Class**
  - Create a new file `src/utils/TilemapManager.ts`.
  - Define a `TilemapManager` class to encapsulate a configurable tilemap.
  - Use `TextureGenerator.generateTexture` to create textures for empty and filled spaces.
  - Set up collision detection for filled spaces in the `TilemapManager` class.
  - Add a method `setTile` to set tiles in the tilemap.

* **PlayScene Update**
  - Import the `TilemapManager` class in `src/scenes/PlayScene.ts`.
  - Initialize and configure the `TilemapManager` in the `create` method.
  - Add an example usage of `setTile` method in the `create` method.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nl12/issues/13?shareId=636fd92b-31af-44cf-8112-101845acde49).