### PR TITLE
Refactor TilemapManager to be stateless and use TilemapData

### DIFF
--- a/src/scenes/PlayScene.ts
+++ b/src/scenes/PlayScene.ts
@@ -20,14 +20,15 @@ class PlayScene extends Phaser.Scene {
 
 	create() {
 		const map = MapGenerator.generateMap(Config.MapWidth, Config.MapHeight, 3);
-		const tilemapManager = new TilemapManager(
+		const tilemapManager = new TilemapManager();
+		const tilemapData = tilemapManager.createTilemap(
 			this,
 			Config.MapWidth,
 			Config.MapHeight,
 			Config.TileWidth,
 			Config.TileHeight,
 		);
-		tilemapManager.populateTilemap(map);
+		tilemapManager.populateTilemap(map, tilemapData);
 	}
 
 	update() {

--- a/src/utils/TilemapManager.ts
+++ b/src/utils/TilemapManager.ts
@@ -1,30 +1,16 @@
 import Phaser from "phaser";
 import TextureGenerator from "./TextureGenerator";
 
-class TilemapManager {
-	private tilemapData: {
-		scene: Phaser.Scene;
-		tilemap: Phaser.Tilemaps.Tilemap;
-		emptyTileset: Phaser.Tilemaps.Tileset;
-		filledTileset: Phaser.Tilemaps.Tileset;
-		layer: Phaser.Tilemaps.TilemapLayer;
-	};
+type TilemapData = {
+	scene: Phaser.Scene;
+	tilemap: Phaser.Tilemaps.Tilemap;
+	emptyTileset: Phaser.Tilemaps.Tileset;
+	filledTileset: Phaser.Tilemaps.Tileset;
+	layer: Phaser.Tilemaps.TilemapLayer;
+};
 
-	constructor(
-		scene: Phaser.Scene,
-		width: number,
-		height: number,
-		tileWidth: number,
-		tileHeight: number,
-	) {
-		this.tilemapData = this.createTilemap(
-			scene,
-			width,
-			height,
-			tileWidth,
-			tileHeight,
-		);
-	}
+class TilemapManager {
+	constructor() {}
 
 	private createTilemap(
 		scene: Phaser.Scene,
@@ -32,7 +18,7 @@ class TilemapManager {
 		height: number,
 		tileWidth: number,
 		tileHeight: number,
-	) {
+	): TilemapData {
 		TextureGenerator.generateTexture(
 			scene,
 			0xff00ff,
@@ -102,16 +88,16 @@ class TilemapManager {
 		layer.setCollisionBetween(filledTileset.firstgid, filledTileset.firstgid);
 	}
 
-	public setTile(x: number, y: number, filled: boolean) {
-		const { tilemap, filledTileset, emptyTileset, layer } = this.tilemapData;
+	public setTile(x: number, y: number, filled: boolean, tilemapData: TilemapData) {
+		const { tilemap, filledTileset, emptyTileset, layer } = tilemapData;
 		const tileIndex = filled ? filledTileset.firstgid : emptyTileset.firstgid;
 		tilemap.putTileAt(tileIndex, x, y, true, layer);
 	}
 
-	public populateTilemap(map: boolean[][]) {
+	public populateTilemap(map: boolean[][], tilemapData: TilemapData) {
 		for (let y = 0; y < map.length; y++) {
 			for (let x = 0; x < map[y].length; x++) {
-				this.setTile(x, y, map[y][x]);
+				this.setTile(x, y, map[y][x], tilemapData);
 			}
 		}
 	}

--- a/src/utils/TilemapManager.ts
+++ b/src/utils/TilemapManager.ts
@@ -12,7 +12,7 @@ type TilemapData = {
 class TilemapManager {
 	constructor() {}
 
-	private createTilemap(
+	createTilemap(
 		scene: Phaser.Scene,
 		width: number,
 		height: number,
@@ -85,10 +85,15 @@ class TilemapManager {
 		layer: Phaser.Tilemaps.TilemapLayer;
 		filledTileset: Phaser.Tilemaps.Tileset;
 	}) {
-		layer.setCollisionBetween(filledTileset.firstgid, filledTileset.firstgid);
+		layer.setCollision(filledTileset.firstgid);
 	}
 
-	public setTile(x: number, y: number, filled: boolean, tilemapData: TilemapData) {
+	public setTile(
+		x: number,
+		y: number,
+		filled: boolean,
+		tilemapData: TilemapData,
+	) {
 		const { tilemap, filledTileset, emptyTileset, layer } = tilemapData;
 		const tileIndex = filled ? filledTileset.firstgid : emptyTileset.firstgid;
 		tilemap.putTileAt(tileIndex, x, y, true, layer);


### PR DESCRIPTION
Related to #21

Refactor TilemapManager to be stateless and accept a TilemapData object as a parameter.

* Define a TilemapData type with properties: scene, tilemap, emptyTileset, filledTileset, and layer.
* Remove the tilemapData class property from TilemapManager.
* Modify the setTile and populateTilemap methods to accept a TilemapData object as a parameter.
* Update the createTilemap method to return a TilemapData object.
* In PlayScene, create a TilemapData object and pass it to the populateTilemap method of TilemapManager.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nl12/pull/22?shareId=cf1f13cd-e947-4fae-bd16-2602e532290c).