### PR TITLE
Add a method to find a random non-filled tile in TilemapManager

### DIFF
--- a/src/utils/TilemapManager.ts
+++ b/src/utils/TilemapManager.ts
@@ -106,6 +106,27 @@ class TilemapManager {
 			}
 		}
 	}
+
+	public findRandomNonFilledTile(tilemapData: TilemapData): { x: number, y: number } | null {
+		const { tilemap, emptyTileset } = tilemapData;
+		const nonFilledTiles: { x: number, y: number }[] = [];
+
+		for (let y = 0; y < tilemap.height; y++) {
+			for (let x = 0; x < tilemap.width; x++) {
+				const tile = tilemap.getTileAt(x, y);
+				if (tile && tile.index === emptyTileset.firstgid) {
+					nonFilledTiles.push({ x, y });
+				}
+			}
+		}
+
+		if (nonFilledTiles.length === 0) {
+			return null;
+		}
+
+		const randomIndex = Math.floor(Math.random() * nonFilledTiles.length);
+		return nonFilledTiles[randomIndex];
+	}
 }
 
 export default TilemapManager;


### PR DESCRIPTION
Related to #23

Add a method to find a random non-filled tile in the TilemapManager class.

* Add `findRandomNonFilledTile` method to `TilemapManager` class in `src/utils/TilemapManager.ts`.
* Implement the method to iterate through the tilemap and find all non-filled tiles.
* Return a random non-filled tile's coordinates as an object with `x` and `y` properties.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nl12/pull/24?shareId=5a6c6c6b-57a3-4a65-b41e-a518668982ce).