### PR TITLE
Fix player collision with filled tiles

### DIFF
--- a/src/objects/Player.ts
+++ b/src/objects/Player.ts
@@ -71,6 +71,17 @@ class Player extends Phaser.Physics.Arcade.Sprite {
 			this.stateMachine[this.currentState].onEnter();
 		}
 		this.stateMachine[this.currentState].onExecute();
+
+		// Handle collisions with filled tiles
+		if (this.body.blocked.down || this.body.touching.down) {
+			this.setVelocityY(0);
+		}
+		if (this.body.blocked.left || this.body.touching.left) {
+			this.setVelocityX(0);
+		}
+		if (this.body.blocked.right || this.body.touching.right) {
+			this.setVelocityX(0);
+		}
 	}
 }
 

--- a/src/scenes/PlayScene.ts
+++ b/src/scenes/PlayScene.ts
@@ -53,6 +53,7 @@ class PlayScene extends Phaser.Scene {
 				Config.TileHeight,
 			);
 			this.physics.add.existing(this.player);
+			this.physics.add.collider(this.player, tilemapData.layer);
 		}
 	}
 
@@ -61,6 +62,7 @@ class PlayScene extends Phaser.Scene {
 		const inputs = this.inputManager.getInputs();
 		if (this.player) {
 			this.player.updateState(inputs);
+			this.physics.collide(this.player, this.physics.world.bounds);
 		}
 	}
 }


### PR DESCRIPTION
Related to #44

Add collision detection between the player and filled tiles.

* Modify `src/scenes/PlayScene.ts` to add collision detection between the player and filled tiles in the `create` and `update` methods.
* Modify `src/objects/Player.ts` to handle collisions with filled tiles in the `updateState` method.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nl12/pull/45?shareId=4c7a2c23-1640-411e-8e1d-7443075cb231).