### PR TITLE
Transition from IDLE to RUNNING if either left or right inputs are true

### DIFF
--- a/src/objects/Player.ts
+++ b/src/objects/Player.ts
@@ -47,16 +47,28 @@ class Player extends Phaser.Physics.Arcade.Sprite {
 	private stateMachine = {
 		[PlayerState.IDLE]: {
 			onEnter: () => {},
-			onExecute: () => {},
+			onExecute: (inputs: { left: boolean; right: boolean }) => {
+				if (inputs.left || inputs.right) {
+					this.nextState = PlayerState.RUNNING;
+				}
+			},
 			onExit: () => {},
 			onCollision: () => {
 				this.nextState = PlayerState.IDLE;
 			},
 		},
 		[PlayerState.RUNNING]: {
-			onEnter: () => {},
+			onEnter: (inputs: { left: boolean; right: boolean }) => {
+				if (inputs.left) {
+					this.setVelocityX(-200);
+				} else if (inputs.right) {
+					this.setVelocityX(200);
+				}
+			},
 			onExecute: () => {},
-			onExit: () => {},
+			onExit: () => {
+				this.setVelocityX(0);
+			},
 			onCollision: () => {
 				this.nextState = PlayerState.IDLE;
 			},
@@ -100,9 +112,9 @@ class Player extends Phaser.Physics.Arcade.Sprite {
 		if (this.nextState !== this.currentState) {
 			this.stateMachine[this.currentState].onExit();
 			this.currentState = this.nextState;
-			this.stateMachine[this.currentState].onEnter();
+			this.stateMachine[this.currentState].onEnter(inputs);
 		}
-		this.stateMachine[this.currentState].onExecute();
+		this.stateMachine[this.currentState].onExecute(inputs);
 	}
 }
 

--- a/src/objects/Player.ts
+++ b/src/objects/Player.ts
@@ -115,6 +115,14 @@ class Player extends Phaser.Physics.Arcade.Sprite {
 			this.stateMachine[this.currentState].onEnter(inputs);
 		}
 		this.stateMachine[this.currentState].onExecute(inputs);
+
+		// Print the current state of the player over the player sprite using a bright, small, legible font
+		const stateText = this.scene.add.text(this.x, this.y - 20, PlayerState[this.currentState], {
+			fontSize: '12px',
+			color: '#ffffff',
+			backgroundColor: '#000000',
+		});
+		stateText.setOrigin(0.5, 0.5);
 	}
 }
 


### PR DESCRIPTION
Related to #52

Add logic to transition from IDLE to RUNNING state based on left or right inputs in `src/objects/Player.ts`.

* Update `onExecute` method for `PlayerState.IDLE` to check for left or right inputs and transition to `PlayerState.RUNNING`.
* Update `onEnter` method for `PlayerState.RUNNING` to set the player's velocity based on the direction of the inputs.
* Update `onExit` method for `PlayerState.RUNNING` to stop the player's velocity.
* Pass `inputs` to `onEnter` and `onExecute` methods in the state machine.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nl12/pull/53?shareId=a5d4ffd9-35fd-4a85-a2e0-a2f17d2f3219).