### PR TITLE
Display player's current state above the player sprite

### DIFF
--- a/src/objects/Player.ts
+++ b/src/objects/Player.ts
@@ -12,6 +12,7 @@ enum PlayerState {
 class Player extends Phaser.Physics.Arcade.Sprite {
 	private currentState: PlayerState;
 	private nextState: PlayerState;
+	private stateText: Phaser.GameObjects.Text;
 
 	constructor(
 		scene: Phaser.Scene,
@@ -34,6 +35,11 @@ class Player extends Phaser.Physics.Arcade.Sprite {
 		this.setTexture("player");
 		this.setOrigin(0, 0);
 		this.body?.setSize(width, height);
+
+		this.stateText = this.scene.add.text(this.x, this.y - 20, this.getStateText(), {
+			fontSize: '16px',
+			color: '#ffffff',
+		});
 	}
 
 	private stateMachine = {
@@ -93,8 +99,27 @@ class Player extends Phaser.Physics.Arcade.Sprite {
 			this.stateMachine[this.currentState].onExit();
 			this.currentState = this.nextState;
 			this.stateMachine[this.currentState].onEnter();
+			this.stateText.setText(this.getStateText());
 		}
 		this.stateMachine[this.currentState].onExecute();
+		this.stateText.setPosition(this.x, this.y - 20);
+	}
+
+	private getStateText(): string {
+		switch (this.currentState) {
+			case PlayerState.IDLE:
+				return "IDLE";
+			case PlayerState.RUNNING:
+				return "RUNNING";
+			case PlayerState.JUMPING:
+				return "JUMPING";
+			case PlayerState.FALLING:
+				return "FALLING";
+			case PlayerState.GLIDING:
+				return "GLIDING";
+			default:
+				return "";
+		}
 	}
 }
 


### PR DESCRIPTION
Related to #54

Add a text object to display the player's current state above the player sprite.

* Add a `Phaser.GameObjects.Text` object to `Player` class to display the player's current state.
* Update the text object with the player's current state whenever the state changes.
* Position the text object above the player sprite and update its position in the `updateState` method.
* Add a `getStateText` method to return the current state's text representation.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nl12/pull/55?shareId=57c5ac02-cb8e-4005-b94e-8374de0e3ee1).