### PR TITLE
Type the stateMachine in the Player class

### DIFF
--- a/src/objects/Player.ts
+++ b/src/objects/Player.ts
@@ -10,6 +10,13 @@ enum PlayerState {
 	GLIDING,
 }
 
+interface State {
+	onEnter: () => void;
+	onExecute: () => void;
+	onExit: () => void;
+	onCollision: () => void;
+}
+
 class Player extends Phaser.Physics.Arcade.Sprite {
 	private currentState: PlayerState;
 	private nextState: PlayerState;
@@ -43,7 +50,7 @@ class Player extends Phaser.Physics.Arcade.Sprite {
 		});
 	}
 
-	private stateMachine = {
+	private stateMachine: { [key in PlayerState]: State } = {
 		[PlayerState.IDLE]: {
 			onEnter: () => {},
 			onExecute: () => {},


### PR DESCRIPTION
Related to #61

Type the `stateMachine` in the `Player` class.

* Define a new `State` interface to type the `stateMachine` object.
* Update the `stateMachine` object to use the `State` interface.
* Ensure the `stateMachine` object uses the `PlayerState` enum to define its keys.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nl12/pull/62?shareId=f3469445-ddcb-4079-84a9-a11afca08bc8).