### PR TITLE
Pass the Inputs object as a parameter to the state machine's onEnter, onExecute, and onExit methods

### DIFF
--- a/src/objects/Player.ts
+++ b/src/objects/Player.ts
@@ -11,9 +11,9 @@ enum PlayerState {
 }
 
 interface State {
-	onEnter: () => void;
-	onExecute: () => void;
-	onExit: () => void;
+	onEnter: (inputs: Inputs) => void;
+	onExecute: (inputs: Inputs) => void;
+	onExit: (inputs: Inputs) => void;
 	onCollision: () => void;
 }
 
@@ -52,41 +52,41 @@ class Player extends Phaser.Physics.Arcade.Sprite {
 
 	private stateMachine: { [key in PlayerState]: State } = {
 		[PlayerState.IDLE]: {
-			onEnter: () => {},
-			onExecute: () => {},
-			onExit: () => {},
+			onEnter: (inputs: Inputs) => {},
+			onExecute: (inputs: Inputs) => {},
+			onExit: (inputs: Inputs) => {},
 			onCollision: () => {
 				this.nextState = PlayerState.IDLE;
 			},
 		},
 		[PlayerState.RUNNING]: {
-			onEnter: () => {},
-			onExecute: () => {},
-			onExit: () => {},
+			onEnter: (inputs: Inputs) => {},
+			onExecute: (inputs: Inputs) => {},
+			onExit: (inputs: Inputs) => {},
 			onCollision: () => {
 				this.nextState = PlayerState.IDLE;
 			},
 		},
 		[PlayerState.JUMPING]: {
-			onEnter: () => {},
-			onExecute: () => {},
-			onExit: () => {},
+			onEnter: (inputs: Inputs) => {},
+			onExecute: (inputs: Inputs) => {},
+			onExit: (inputs: Inputs) => {},
 			onCollision: () => {
 				this.nextState = PlayerState.FALLING;
 			},
 		},
 		[PlayerState.FALLING]: {
-			onEnter: () => {},
-			onExecute: () => {},
-			onExit: () => {},
+			onEnter: (inputs: Inputs) => {},
+			onExecute: (inputs: Inputs) => {},
+			onExit: (inputs: Inputs) => {},
 			onCollision: () => {
 				this.nextState = PlayerState.IDLE;
 			},
 		},
 		[PlayerState.GLIDING]: {
-			onEnter: () => {},
-			onExecute: () => {},
-			onExit: () => {},
+			onEnter: (inputs: Inputs) => {},
+			onExecute: (inputs: Inputs) => {},
+			onExit: (inputs: Inputs) => {},
 			onCollision: () => {
 				this.nextState = PlayerState.FALLING;
 			},
@@ -99,12 +99,12 @@ class Player extends Phaser.Physics.Arcade.Sprite {
 
 	public updateState(inputs: Inputs) {
 		if (this.nextState !== this.currentState) {
-			this.stateMachine[this.currentState].onExit();
+			this.stateMachine[this.currentState].onExit(inputs);
 			this.currentState = this.nextState;
-			this.stateMachine[this.currentState].onEnter();
+			this.stateMachine[this.currentState].onEnter(inputs);
 			this.stateText.setText(this.getStateText());
 		}
-		this.stateMachine[this.currentState].onExecute();
+		this.stateMachine[this.currentState].onExecute(inputs);
 		this.stateText.setPosition(this.x, this.y - 20);
 	}
 


### PR DESCRIPTION
Related to #63

Pass the `Inputs` object as a parameter to the state machine's `onEnter`, `onExecute`, and `onExit` methods in the `Player` class.

* **State Interface**: Update the `State` interface to include `inputs: Inputs` as a parameter in the `onEnter`, `onExecute`, and `onExit` methods.
* **State Machine**: Update the `stateMachine` object to include `inputs: Inputs` as a parameter in the `onEnter`, `onExecute`, and `onExit` methods for each state (`IDLE`, `RUNNING`, `JUMPING`, `FALLING`, `GLIDING`).
* **Update State Method**: Update the `updateState` method to pass the `inputs` object to the `onEnter`, `onExecute`, and `onExit` methods.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nl12/pull/64?shareId=36a22715-7f9e-47e2-b761-3e48ea1b8785).