### PR TITLE
Implement logic for transitioning from player state IDLE to JUMPING

### DIFF
--- a/src/objects/Player.ts
+++ b/src/objects/Player.ts
@@ -44,10 +44,15 @@ class Player extends Phaser.Physics.Arcade.Sprite {
 		this.setOrigin(0, 0);
 		this.body?.setSize(width, height);
 
-		this.stateText = this.scene.add.text(this.x, this.y - 20, this.getStateText(), {
-			fontSize: '16px',
-			color: '#ffffff',
-		});
+		this.stateText = this.scene.add.text(
+			this.x,
+			this.y - 20,
+			this.getStateText(),
+			{
+				fontSize: "16px",
+				color: "#ffffff",
+			},
+		);
 	}
 
 	private stateMachine: { [key in PlayerState]: State } = {
@@ -59,17 +64,13 @@ class Player extends Phaser.Physics.Arcade.Sprite {
 				}
 			},
 			onExit: (inputs: Inputs) => {},
-			onCollision: () => {
-				this.nextState = PlayerState.IDLE;
-			},
+			onCollision: () => {},
 		},
 		[PlayerState.RUNNING]: {
 			onEnter: (inputs: Inputs) => {},
 			onExecute: (inputs: Inputs) => {},
 			onExit: (inputs: Inputs) => {},
-			onCollision: () => {
-				this.nextState = PlayerState.IDLE;
-			},
+			onCollision: () => {},
 		},
 		[PlayerState.JUMPING]: {
 			onEnter: (inputs: Inputs) => {
@@ -77,25 +78,19 @@ class Player extends Phaser.Physics.Arcade.Sprite {
 			},
 			onExecute: (inputs: Inputs) => {},
 			onExit: (inputs: Inputs) => {},
-			onCollision: () => {
-				this.nextState = PlayerState.FALLING;
-			},
+			onCollision: () => {},
 		},
 		[PlayerState.FALLING]: {
 			onEnter: (inputs: Inputs) => {},
 			onExecute: (inputs: Inputs) => {},
 			onExit: (inputs: Inputs) => {},
-			onCollision: () => {
-				this.nextState = PlayerState.IDLE;
-			},
+			onCollision: () => {},
 		},
 		[PlayerState.GLIDING]: {
 			onEnter: (inputs: Inputs) => {},
 			onExecute: (inputs: Inputs) => {},
 			onExit: (inputs: Inputs) => {},
-			onCollision: () => {
-				this.nextState = PlayerState.FALLING;
-			},
+			onCollision: () => {},
 		},
 	};
 
@@ -132,7 +127,11 @@ class Player extends Phaser.Physics.Arcade.Sprite {
 	}
 
 	private isBlockedFromBelow(): boolean {
-		return this.body.blocked.down;
+		if (this.body) {
+			return this.body.blocked.down;
+		} else {
+			throw new Error("Cannot access this.body because it's null");
+		}
 	}
 }
 

--- a/src/objects/Player.ts
+++ b/src/objects/Player.ts
@@ -53,7 +53,11 @@ class Player extends Phaser.Physics.Arcade.Sprite {
 	private stateMachine: { [key in PlayerState]: State } = {
 		[PlayerState.IDLE]: {
 			onEnter: (inputs: Inputs) => {},
-			onExecute: (inputs: Inputs) => {},
+			onExecute: (inputs: Inputs) => {
+				if (inputs.up && this.isBlockedFromBelow()) {
+					this.nextState = PlayerState.JUMPING;
+				}
+			},
 			onExit: (inputs: Inputs) => {},
 			onCollision: () => {
 				this.nextState = PlayerState.IDLE;
@@ -68,7 +72,9 @@ class Player extends Phaser.Physics.Arcade.Sprite {
 			},
 		},
 		[PlayerState.JUMPING]: {
-			onEnter: (inputs: Inputs) => {},
+			onEnter: (inputs: Inputs) => {
+				this.body.setVelocityY(-300); // Add vertical impulse
+			},
 			onExecute: (inputs: Inputs) => {},
 			onExit: (inputs: Inputs) => {},
 			onCollision: () => {
@@ -123,6 +129,10 @@ class Player extends Phaser.Physics.Arcade.Sprite {
 			default:
 				return "";
 		}
+	}
+
+	private isBlockedFromBelow(): boolean {
+		return this.body.blocked.down;
 	}
 }
 


### PR DESCRIPTION
Related to #65

Implement logic for transitioning from player state IDLE to JUMPING.

* Add `isBlockedFromBelow` method to check if the player is blocked from below using `body.blocked.down`.
* Modify `onEnter` method for the `PlayerState.JUMPING` state to add a vertical impulse to the player.
* Update `onExecute` method for the `PlayerState.IDLE` state to check for the up input and the collision condition to transition to the JUMPING state.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nl12/pull/66?shareId=f7ebe005-1c53-4c4d-b12c-fb8338a44436).