### PR TITLE
Implement logic for transition from JUMPING state to FALLING

### DIFF
--- a/src/objects/Player.ts
+++ b/src/objects/Player.ts
@@ -76,7 +76,11 @@ class Player extends Phaser.Physics.Arcade.Sprite {
 			onEnter: (inputs: Inputs) => {
 				this.body.setVelocityY(-300); // Add vertical impulse
 			},
-			onExecute: (inputs: Inputs) => {},
+			onExecute: (inputs: Inputs) => {
+				if (this.body.velocity.y > 0) {
+					this.nextState = PlayerState.FALLING;
+				}
+			},
 			onExit: (inputs: Inputs) => {},
 			onCollision: () => {},
 		},


### PR DESCRIPTION
Related to #67

Update the `onExecute` method for the `JUMPING` state to transition to `FALLING` when the player starts moving downward.

* Check if the player's vertical velocity is greater than zero in the `onExecute` method for the `JUMPING` state.
* Set the next state to `FALLING` if the player's vertical velocity is greater than zero.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nl12/pull/68?shareId=c78a9f07-786e-4778-ba15-58896f94a700).