### PR TITLE
Add logic for transitioning from FALLING to IDLE

### DIFF
--- a/src/objects/Player.ts
+++ b/src/objects/Player.ts
@@ -57,7 +57,9 @@ class Player extends Phaser.Physics.Arcade.Sprite {
 
 	private stateMachine: { [key in PlayerState]: State } = {
 		[PlayerState.IDLE]: {
-			onEnter: (inputs: Inputs) => {},
+			onEnter: (inputs: Inputs) => {
+				this.body.setVelocityY(0); // Set vertical velocity to zero
+			},
 			onExecute: (inputs: Inputs) => {
 				if (inputs.up && this.isBlockedFromBelow()) {
 					this.nextState = PlayerState.JUMPING;
@@ -86,7 +88,11 @@ class Player extends Phaser.Physics.Arcade.Sprite {
 		},
 		[PlayerState.FALLING]: {
 			onEnter: (inputs: Inputs) => {},
-			onExecute: (inputs: Inputs) => {},
+			onExecute: (inputs: Inputs) => {
+				if (this.isBlockedFromBelow()) {
+					this.nextState = PlayerState.IDLE;
+				}
+			},
 			onExit: (inputs: Inputs) => {},
 			onCollision: () => {},
 		},


### PR DESCRIPTION
Related to #69

Add logic for transitioning from FALLING to IDLE when blocked from below.

* Modify `PlayerState.IDLE` state's `onEnter` method to set the player's vertical velocity to zero.
* Add logic in the `PlayerState.FALLING` state's `onExecute` method to transition to `IDLE` if the player is blocked from below.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nl12/pull/70?shareId=cf8eb3a7-5844-4915-85c9-9f1baee9216a).