### PR TITLE
Add logic for state transition from IDLE to RUNNING

### DIFF
--- a/src/objects/Player.ts
+++ b/src/objects/Player.ts
@@ -63,18 +63,41 @@ class Player extends Phaser.Physics.Arcade.Sprite {
 			onExecute: (inputs: Inputs) => {
 				if (inputs.up && this.isBlockedFromBelow()) {
 					this.nextState = PlayerState.JUMPING;
+					return;
+				}
+				if (inputs.left || inputs.right) {
+					this.nextState = PlayerState.RUNNING;
 				}
 			},
 			onExit: (inputs: Inputs) => {},
 			onCollision: () => {},
 		},
 		[PlayerState.RUNNING]: {
-			onEnter: (inputs: Inputs) => {},
-			onExecute: (inputs: Inputs) => {},
+			onEnter: (inputs: Inputs) => {
+				if (inputs.left && !inputs.right) {
+					this.body.setVelocityX(-150);
+				} else if (inputs.right && !inputs.left) {
+					this.body.setVelocityX(150);
+				} else {
+					this.body.setVelocityX(0);
+				}
+			},
+			onExecute: (inputs: Inputs) => {
+				if (inputs.left && !inputs.right) {
+					this.body.setVelocityX(-150);
+				} else if (inputs.right && !inputs.left) {
+					this.body.setVelocityX(150);
+				} else {
+					this.body.setVelocityX(0);
+				}
+				if (!inputs.left && !inputs.right) {
+					this.nextState = PlayerState.IDLE;
+				}
+			},
 			onExit: (inputs: Inputs) => {},
 			onCollision: () => {},
 		},
-		[PlayerState.JUMPING]: {
+			[PlayerState.JUMPING]: {
 			onEnter: (inputs: Inputs) => {
 				this.body.setVelocityY(-300); // Add vertical impulse
 			},


### PR DESCRIPTION
Related to #71

Add logic for state transition from IDLE to RUNNING state in `Player.ts`.

* Update `onExecute` method in `PlayerState.IDLE` to check for left or right inputs and transition to `PlayerState.RUNNING`.
* Update `onEnter` method in `PlayerState.RUNNING` to set initial horizontal velocity based on left or right inputs.
* Update `onExecute` method in `PlayerState.RUNNING` to set horizontal velocity based on left or right inputs.
* Update `onExecute` method in `PlayerState.RUNNING` to transition to `PlayerState.IDLE` if neither left nor right inputs are true.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nl12/pull/72?shareId=7a00b6e3-d7c9-4fda-aae3-956b81d375f5).