### PR TITLE
Add logic for transition from FALLING to GLIDING

### DIFF
--- a/src/objects/Player.ts
+++ b/src/objects/Player.ts
@@ -116,6 +116,10 @@ class Player extends Phaser.Physics.Arcade.Sprite {
 		[PlayerState.FALLING]: {
 			onEnter: (inputs: Inputs) => {},
 			onExecute: (inputs: Inputs) => {
+				if (inputs.left || inputs.right) {
+					this.nextState = PlayerState.GLIDING;
+					return;
+				}
 				if (this.isBlockedFromBelow()) {
 					this.nextState = PlayerState.IDLE;
 				}
@@ -125,7 +129,17 @@ class Player extends Phaser.Physics.Arcade.Sprite {
 		},
 		[PlayerState.GLIDING]: {
 			onEnter: (inputs: Inputs) => {},
-			onExecute: (inputs: Inputs) => {},
+			onExecute: (inputs: Inputs) => {
+				if (inputs.left && !inputs.right) {
+					this.body.setVelocityX(-100);
+				} else if (inputs.right && !inputs.left) {
+					this.body.setVelocityX(100);
+				} else if (!inputs.left && !inputs.right) {
+					this.nextState = PlayerState.FALLING;
+				} else if (inputs.left && inputs.right) {
+					this.nextState = PlayerState.FALLING;
+				}
+			},
 			onExit: (inputs: Inputs) => {},
 			onCollision: () => {},
 		},


### PR DESCRIPTION
Related to #75

Add logic for transition from FALLING to GLIDING state.

* Update `onExecute` method in `FALLING` state to check for left or right inputs and transition to `GLIDING` state.
* Update `onExecute` method in `GLIDING` state to handle left and right inputs to add a left or right impulse.
* Update `onExecute` method in `GLIDING` state to transition to `FALLING` state if neither left nor right input is true.
* Update `onExecute` method in `GLIDING` state to transition to `FALLING` state if both left and right inputs are true.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nl12/pull/76?shareId=af994119-e9fb-4468-8638-a73da010678d).