### PR TITLE
Add logic for transition from GLIDING to RUNNING

### DIFF
--- a/src/objects/Player.ts
+++ b/src/objects/Player.ts
@@ -139,6 +139,9 @@ class Player extends Phaser.Physics.Arcade.Sprite {
 				} else if (inputs.left && inputs.right) {
 					this.nextState = PlayerState.FALLING;
 				}
+				if (this.isBlockedFromBelow()) {
+					this.nextState = PlayerState.RUNNING;
+				}
 			},
 			onExit: (inputs: Inputs) => {},
 			onCollision: () => {},


### PR DESCRIPTION
Related to #78

Add logic for transition from GLIDING to RUNNING state when blocked from below.

* Update `onExecute` method for the GLIDING state in `src/objects/Player.ts` to check if the player is blocked from below.
* Set the next state to RUNNING if the player is blocked from below while in the GLIDING state.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nl12/pull/79?shareId=8158f2e4-66ce-41bf-b895-8e515a3f95ac).