### PR TITLE
Add logic for player transition from RUNNING to JUMPING

### DIFF
--- a/src/objects/Player.ts
+++ b/src/objects/Player.ts
@@ -110,6 +110,9 @@ class Player extends Phaser.Physics.Arcade.Sprite {
 				if (!this.isBlockedFromBelow()) {
 					this.nextState = PlayerState.GLIDING;
 				}
+				if (inputs.up && this.isBlockedFromBelow()) {
+					this.nextState = PlayerState.JUMPING;
+				}
 			},
 			onExit: (inputs: Inputs) => {},
 			onCollision: () => {},


### PR DESCRIPTION
Related to #85

Add logic for player transition from RUNNING to JUMPING

* Update the `onExecute` method for the RUNNING state to check for the up input.
* If the up input is true and the player is blocked from below, set the next state to JUMPING.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nl12/pull/86?shareId=7f6ac575-65df-473a-abef-e89f5304608f).