### PR TITLE
Implement singleton TilemapManager and associate Player with TilemapData

### DIFF
--- a/src/objects/Player.ts
+++ b/src/objects/Player.ts
@@ -1,6 +1,7 @@
 import Phaser from "phaser";
 import TextureGenerator from "../utils/TextureGenerator";
 import { Inputs } from "../utils/InputManager";
+import { TilemapData } from "../utils/TilemapManager";
 
 enum PlayerState {
 	IDLE,
@@ -21,6 +22,7 @@ class Player extends Phaser.Physics.Arcade.Sprite {
 	private currentState: PlayerState;
 	private nextState: PlayerState;
 	private stateText: Phaser.GameObjects.Text;
+	private _tilemapData: TilemapData | null = null;
 
 	static readonly RUNNING_VELOCITY = 150;
 	static readonly GLIDING_VELOCITY = 100;
@@ -57,6 +59,14 @@ class Player extends Phaser.Physics.Arcade.Sprite {
 				color: "#ffffff",
 			},
 		);
+	}
+
+	public setTilemapData(tilemapData: TilemapData) {
+		if (tilemapData && tilemapData.tilemap && tilemapData.layer) {
+			this._tilemapData = tilemapData;
+		} else {
+			throw new Error("Invalid TilemapData instance provided");
+		}
 	}
 
 	private getBody(): Phaser.Physics.Arcade.Body {

--- a/src/scenes/PlayScene.ts
+++ b/src/scenes/PlayScene.ts
@@ -25,7 +25,7 @@ class PlayScene extends Phaser.Scene {
 
 	create() {
 		const map = MapGenerator.generateMap(Config.MapWidth, Config.MapHeight, 3);
-		const tilemapManager = new TilemapManager();
+		const tilemapManager = TilemapManager.getInstance();
 		const tilemapData = tilemapManager.createTilemap(
 			this,
 			Config.MapWidth,
@@ -60,6 +60,7 @@ class PlayScene extends Phaser.Scene {
 				undefined,
 				this,
 			);
+			this.player.setTilemapData(tilemapData);
 		}
 	}
 
@@ -68,6 +69,7 @@ class PlayScene extends Phaser.Scene {
 		const inputs = this.inputManager.getInputs();
 		if (this.player) {
 			this.player.updateState(inputs);
+			this.player.setTilemapData(tilemapData);
 		}
 	}
 

--- a/src/utils/TilemapManager.ts
+++ b/src/utils/TilemapManager.ts
@@ -10,7 +10,16 @@ type TilemapData = {
 };
 
 class TilemapManager {
-	constructor() {}
+	private static instance: TilemapManager;
+
+	private constructor() {}
+
+	public static getInstance(): TilemapManager {
+		if (!TilemapManager.instance) {
+			TilemapManager.instance = new TilemapManager();
+		}
+		return TilemapManager.instance;
+	}
 
 	createTilemap(
 		scene: Phaser.Scene,


### PR DESCRIPTION
Related to #92

Implement a singleton pattern for the `TilemapManager` class and associate the player with `TilemapData`.

* **TilemapManager Singleton:**
  - Add a private static instance property to the `TilemapManager` class.
  - Create a public static method `getInstance` to get the instance of the `TilemapManager`.
  - Make the constructor private to prevent direct instantiation.

* **Player Class:**
  - Add a private property `_tilemapData` to hold the `TilemapData` instance.
  - Add a public setter method `setTilemapData` to set the `TilemapData` instance.
  - Add validation logic in the `setTilemapData` method to check if the provided `TilemapData` instance is valid before assigning it to the `_tilemapData` property.

* **PlayScene:**
  - Use the singleton instance of `TilemapManager` instead of creating a new instance.
  - Pass the `TilemapData` instance to the player class using the `setTilemapData` method.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nl12/pull/93?shareId=c64d6e0d-aee6-479b-8604-a30999b601e9).