### PR TITLE
Refactor TilemapManager to be a module

### DIFF
--- a/src/scenes/PlayScene.ts
+++ b/src/scenes/PlayScene.ts
@@ -1,5 +1,5 @@
 import Phaser from "phaser";
-import TilemapManager from "../utils/TilemapManager";
+import * as TilemapManager from "../utils/TilemapManager";
 import MapGenerator from "../utils/MapGenerator";
 import InputManager from "../utils/InputManager";
 import Player from "../objects/Player";
@@ -25,15 +25,14 @@ class PlayScene extends Phaser.Scene {
 
 	create() {
 		const map = MapGenerator.generateMap(Config.MapWidth, Config.MapHeight, 3);
-		const tilemapManager = new TilemapManager();
-		const tilemapData = tilemapManager.createTilemap(
+		const tilemapData = TilemapManager.createTilemap(
 			this,
 			Config.MapWidth,
 			Config.MapHeight,
 			Config.TileWidth,
 			Config.TileHeight,
 		);
-		tilemapManager.populateTilemap(map, tilemapData);
+		TilemapManager.populateTilemap(map, tilemapData);
 		this.physics.world.setBounds(
 			0,
 			0,
@@ -43,7 +42,7 @@ class PlayScene extends Phaser.Scene {
 
 		this.inputManager = new InputManager(this);
 
-		const playerStart = tilemapManager.findRandomNonFilledTile(tilemapData);
+		const playerStart = TilemapManager.findRandomNonFilledTile(tilemapData);
 		if (playerStart) {
 			this.player = new Player(
 				this,

--- a/src/utils/TilemapManager.ts
+++ b/src/utils/TilemapManager.ts
@@ -9,128 +9,124 @@ type TilemapData = {
 	layer: Phaser.Tilemaps.TilemapLayer;
 };
 
-class TilemapManager {
-	constructor() {}
+export function createTilemap(
+	scene: Phaser.Scene,
+	width: number,
+	height: number,
+	tileWidth: number,
+	tileHeight: number,
+): TilemapData {
+	TextureGenerator.generateTexture(
+		scene,
+		0x555555,
+		tileWidth,
+		tileHeight,
+		"empty",
+		{ color: 0x000000, thickness: 1 },
+	);
+	TextureGenerator.generateTexture(
+		scene,
+		0x000000,
+		tileWidth,
+		tileHeight,
+		"filled",
+		{ color: 0xaaaaaa, thickness: 1 },
+	);
 
-	createTilemap(
-		scene: Phaser.Scene,
-		width: number,
-		height: number,
-		tileWidth: number,
-		tileHeight: number,
-	): TilemapData {
-		TextureGenerator.generateTexture(
-			scene,
-			0x555555,
-			tileWidth,
-			tileHeight,
-			"empty",
-			{ color: 0x000000, thickness: 1 },
-		);
-		TextureGenerator.generateTexture(
-			scene,
-			0x000000,
-			tileWidth,
-			tileHeight,
-			"filled",
-			{ color: 0xaaaaaa, thickness: 1 },
-		);
-
-		const tilemap = scene.make.tilemap({
-			width,
-			height,
-			tileWidth,
-			tileHeight,
-		});
-		const filledTileset = tilemap.addTilesetImage(
-			"filled",
-			undefined,
-			tileWidth,
-			tileHeight,
-			0,
-			0,
-			1,
-		);
-		if (!filledTileset) {
-			throw new Error("Failed to create 'filled' TilesetImage");
-		}
-
-		const emptyTileset = tilemap.addTilesetImage(
-			"empty",
-			undefined,
-			tileWidth,
-			tileHeight,
-			0,
-			0,
-			2,
-		);
-		if (!emptyTileset) {
-			throw new Error("Failed to create 'empty' TilesetImage");
-		}
-		const layer = tilemap.createBlankLayer("layer", [
-			emptyTileset,
-			filledTileset,
-		]);
-
-		if (!layer) {
-			throw new Error("Failed to create layer");
-		}
-		this.setupCollision({ layer, filledTileset });
-
-		return { scene, tilemap, emptyTileset, filledTileset, layer };
+	const tilemap = scene.make.tilemap({
+		width,
+		height,
+		tileWidth,
+		tileHeight,
+	});
+	const filledTileset = tilemap.addTilesetImage(
+		"filled",
+		undefined,
+		tileWidth,
+		tileHeight,
+		0,
+		0,
+		1,
+	);
+	if (!filledTileset) {
+		throw new Error("Failed to create 'filled' TilesetImage");
 	}
 
-	private setupCollision({
-		layer,
+	const emptyTileset = tilemap.addTilesetImage(
+		"empty",
+		undefined,
+		tileWidth,
+		tileHeight,
+		0,
+		0,
+		2,
+	);
+	if (!emptyTileset) {
+		throw new Error("Failed to create 'empty' TilesetImage");
+	}
+	const layer = tilemap.createBlankLayer("layer", [
+		emptyTileset,
 		filledTileset,
-	}: {
-		layer: Phaser.Tilemaps.TilemapLayer;
-		filledTileset: Phaser.Tilemaps.Tileset;
-	}) {
-		layer.setCollision(filledTileset.firstgid);
+	]);
+
+	if (!layer) {
+		throw new Error("Failed to create layer");
 	}
+	setupCollision({ layer, filledTileset });
 
-	public setTile(
-		x: number,
-		y: number,
-		filled: boolean,
-		tilemapData: TilemapData,
-	) {
-		const { tilemap, filledTileset, emptyTileset, layer } = tilemapData;
-		const tileIndex = filled ? filledTileset.firstgid : emptyTileset.firstgid;
-		tilemap.putTileAt(tileIndex, x, y, true, layer);
-	}
+	return { scene, tilemap, emptyTileset, filledTileset, layer };
+}
 
-	public populateTilemap(map: boolean[][], tilemapData: TilemapData) {
-		for (let y = 0; y < map.length; y++) {
-			for (let x = 0; x < map[y].length; x++) {
-				this.setTile(x, y, map[y][x], tilemapData);
-			}
+export function setupCollision({
+	layer,
+	filledTileset,
+}: {
+	layer: Phaser.Tilemaps.TilemapLayer;
+	filledTileset: Phaser.Tilemaps.Tileset;
+}) {
+	layer.setCollision(filledTileset.firstgid);
+}
+
+export function setTile(
+	x: number,
+	y: number,
+	filled: boolean,
+	tilemapData: TilemapData,
+) {
+	const { tilemap, filledTileset, emptyTileset, layer } = tilemapData;
+	const tileIndex = filled ? filledTileset.firstgid : emptyTileset.firstgid;
+	tilemap.putTileAt(tileIndex, x, y, true, layer);
+}
+
+export function populateTilemap(map: boolean[][], tilemapData: TilemapData) {
+	for (let y = 0; y < map.length; y++) {
+		for (let x = 0; x < map[y].length; x++) {
+			setTile(x, y, map[y][x], tilemapData);
 		}
-	}
-
-	public findRandomNonFilledTile(
-		tilemapData: TilemapData,
-	): { x: number; y: number } | null {
-		const { tilemap, emptyTileset } = tilemapData;
-		const nonFilledTiles: { x: number; y: number }[] = [];
-
-		for (let y = 0; y < tilemap.height; y++) {
-			for (let x = 0; x < tilemap.width; x++) {
-				const tile = tilemap.getTileAt(x, y);
-				if (tile && tile.index === emptyTileset.firstgid) {
-					nonFilledTiles.push({ x, y });
-				}
-			}
-		}
-
-		if (nonFilledTiles.length === 0) {
-			return null;
-		}
-
-		const randomIndex = Math.floor(Math.random() * nonFilledTiles.length);
-		return nonFilledTiles[randomIndex];
 	}
 }
 
-export default TilemapManager;
+export function findRandomNonFilledTile(
+	tilemapData: TilemapData,
+): { x: number; y: number } | null {
+	const { tilemap, emptyTileset } = tilemapData;
+	const nonFilledTiles: { x: number; y: number }[] = [];
+
+	for (let y = 0; y < tilemap.height; y++) {
+		for (let x = 0; x < tilemap.width; x++) {
+			const tile = tilemap.getTileAt(x, y);
+			if (tile && tile.index === emptyTileset.firstgid) {
+				nonFilledTiles.push({ x, y });
+			}
+		}
+	}
+
+	if (nonFilledTiles.length === 0) {
+		return null;
+	}
+
+	const randomIndex = Math.floor(Math.random() * nonFilledTiles.length);
+	return nonFilledTiles[randomIndex];
+}
+
+export type { TilemapData };


### PR DESCRIPTION
Related to #94

Convert `TilemapManager` class to a module with exported functions.

* **TilemapManager Module:**
  - Remove the `TilemapManager` class and its constructor.
  - Export functions: `createTilemap`, `setupCollision`, `setTile`, `populateTilemap`, and `findRandomNonFilledTile`.
  - Retain and export the `TilemapData` type.

* **PlayScene:**
  - Replace the instantiation of `TilemapManager` with direct function calls to the exported functions from `TilemapManager` module.
  - Use `import * as` syntax to import all the exports from `TilemapManager`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nl12/pull/95?shareId=883219ad-6308-405e-a525-b0f3310f8b5e).