### PR TITLE
Refactor to combine the properties of TilemapData into TilemapManager

### DIFF
--- a/src/scenes/PlayScene.ts
+++ b/src/scenes/PlayScene.ts
@@ -26,14 +26,14 @@ class PlayScene extends Phaser.Scene {
 	create() {
 		const map = MapGenerator.generateMap(Config.MapWidth, Config.MapHeight, 3);
 		const tilemapManager = new TilemapManager();
-		const tilemapData = tilemapManager.createTilemap(
+		tilemapManager.createTilemap(
 			this,
 			Config.MapWidth,
 			Config.MapHeight,
 			Config.TileWidth,
 			Config.TileHeight,
 		);
-		tilemapManager.populateTilemap(map, tilemapData);
+		tilemapManager.populateTilemap(map);
 		this.physics.world.setBounds(
 			0,
 			0,
@@ -43,7 +43,7 @@ class PlayScene extends Phaser.Scene {
 
 		this.inputManager = new InputManager(this);
 
-		const playerStart = tilemapManager.findRandomNonFilledTile(tilemapData);
+		const playerStart = tilemapManager.findRandomNonFilledTile();
 		if (playerStart) {
 			this.player = new Player(
 				this,
@@ -55,7 +55,7 @@ class PlayScene extends Phaser.Scene {
 			this.physics.add.existing(this.player);
 			this.physics.add.collider(
 				this.player,
-				tilemapData.layer,
+				tilemapManager.layer,
 				this.handlePlayerCollision,
 				undefined,
 				this,


### PR DESCRIPTION
Related to #97

Refactor to combine the properties of `TilemapData` into `TilemapManager` and eliminate the `TilemapData` class.

* Remove `TilemapData` type definition from `src/utils/TilemapManager.ts`.
* Add properties `scene`, `tilemap`, `emptyTileset`, `filledTileset`, and `layer` to `TilemapManager` class.
* Update `createTilemap` method to initialize class properties instead of returning `TilemapData`.
* Update methods `setTile`, `populateTilemap`, and `findRandomNonFilledTile` to use class properties directly.
* Update `create` method in `src/scenes/PlayScene.ts` to use `TilemapManager` properties directly instead of `TilemapData`.
* Update `handlePlayerCollision` method in `src/scenes/PlayScene.ts` to use `TilemapManager` properties directly instead of `TilemapData`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nl12/pull/98?shareId=1f30133e-b2f6-41f3-aad3-b40c6d842aa9).