### PR TITLE
Implement a grappling state for the player

### DIFF
--- a/src/utils/InputManager.ts
+++ b/src/utils/InputManager.ts
@@ -5,15 +5,18 @@ type Inputs = {
 	down: boolean;
 	left: boolean;
 	right: boolean;
+	grappling: boolean;
 };
 
 class InputManager {
 	private inputs: Inputs;
 	private cursors: Phaser.Types.Input.Keyboard.CursorKeys;
+	private grapplingKey: Phaser.Input.Keyboard.Key;
 
 	constructor(scene: Phaser.Scene) {
-		this.inputs = { up: false, down: false, left: false, right: false };
+		this.inputs = { up: false, down: false, left: false, right: false, grappling: false };
 		this.cursors = scene.input.keyboard.createCursorKeys();
+		this.grapplingKey = scene.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.SHIFT);
 	}
 
 	public update() {
@@ -21,6 +24,7 @@ class InputManager {
 		this.inputs.down = this.cursors.down.isDown;
 		this.inputs.left = this.cursors.left.isDown;
 		this.inputs.right = this.cursors.right.isDown;
+		this.inputs.grappling = this.grapplingKey.isDown;
 	}
 
 	public getInputs(): Inputs {

--- a/src/utils/TilemapManager.ts
+++ b/src/utils/TilemapManager.ts
@@ -124,6 +124,16 @@ class TilemapManager {
 		const randomIndex = Math.floor(Math.random() * nonFilledTiles.length);
 		return nonFilledTiles[randomIndex];
 	}
+
+	public findFirstFilledTileAbove(x: number, y: number): { x: number; y: number } | null {
+		for (let ty = y; ty >= 0; ty--) {
+			const tile = this.tilemap.getTileAt(x, ty);
+			if (tile && tile.index === this.filledTileset.firstgid) {
+				return { x, y: ty };
+			}
+		}
+		return null;
+	}
 }
 
 export default TilemapManager;


### PR DESCRIPTION
Related to #89

Implement a GRAPPLING state for the player.

* Add a method `findFirstFilledTileAbove` to `TilemapManager` to determine the first filled tile above a given (x,y) coordinate.
* Add a `GRAPPLING` state to the `PlayerState` enum and the state machine in `Player.ts`.
  * Set horizontal velocity to 0 in the GRAPPLING state.
  * Draw a line from the center of the player to the bottom edge of the anchor tile in the GRAPPLING state.
  * Raise or lower the player based on up/down inputs in the GRAPPLING state.
  * Transition to FALLING state if the grappling input becomes false in the GRAPPLING state.
  * Remove the grappling line when exiting the GRAPPLING state.
* Add methods to `Player.ts` to set the current map and compute the grappling hook anchor tile.
* Add a grappling input to the `Inputs` type and the `InputManager` class (left shift key).

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nl12/pull/99?shareId=895f996a-6c9d-4236-b2f6-8ee0a9c778da).