### PR TITLE
Fix the grappling behavior

### DIFF
--- a/src/objects/Player.ts
+++ b/src/objects/Player.ts
@@ -292,7 +292,11 @@ class Player extends Phaser.Physics.Arcade.Sprite {
 		}
 		const playerTileX = Math.floor(this.x / this.currentMap.tilemap.tileWidth);
 		const playerTileY = Math.floor(this.y / this.currentMap.tilemap.tileHeight);
-		return this.currentMap.getFirstFilledTileAbove(playerTileX, playerTileY);
+		const anchorTile = this.currentMap.getFirstFilledTileAbove(playerTileX, playerTileY);
+		if (anchorTile) {
+			return { x: anchorTile.x, y: anchorTile.y + 1 };
+		}
+		return null;
 	}
 }
 


### PR DESCRIPTION
Related to #106

Update the grappling hook behavior to start from the center of the player and connect to the bottom edge of the first filled tile above the player.

* Modify the `getGrapplingHookAnchorTile` method in `src/objects/Player.ts` to return the bottom edge coordinates of the first filled tile above the player.
* Add a check to ensure the anchor tile is not null before returning its coordinates.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nl12/pull/107?shareId=b3fb4044-e1e2-40a9-90e6-cf8344794fc6).