### PR TITLE
Use Phaser's Tilemap.getTileAtWorldXY method

### DIFF
--- a/src/objects/Player.ts
+++ b/src/objects/Player.ts
@@ -290,9 +290,11 @@ class Player extends Phaser.Physics.Arcade.Sprite {
 		if (!this.currentMap) {
 			throw new Error("Current map is not set");
 		}
-		const playerTileX = Math.floor(this.x / this.currentMap.tilemap.tileWidth);
-		const playerTileY = Math.floor(this.y / this.currentMap.tilemap.tileHeight);
-		return this.currentMap.getFirstFilledTileAbove(playerTileX, playerTileY);
+		const tile = this.currentMap.tilemap.getTileAtWorldXY(this.x, this.y);
+		if (tile) {
+			return this.currentMap.getFirstFilledTileAbove(tile.x, tile.y);
+		}
+		return null;
 	}
 }
 

--- a/src/objects/Player.ts
+++ b/src/objects/Player.ts
@@ -290,7 +290,7 @@ class Player extends Phaser.Physics.Arcade.Sprite {
 		if (!this.currentMap) {
 			throw new Error("Current map is not set");
 		}
-		const tile = this.currentMap.tilemap.getTileAtWorldXY(this.x, this.y);
+		const tile = this.currentMap.tilemap.getTileAtWorldXY(this.x + this.width / 2, this.y + this.height / 2);
 		if (tile) {
 			return this.currentMap.getFirstFilledTileAbove(tile.x, tile.y);
 		}


### PR DESCRIPTION
Related to #109

Update `getGrapplingHookAnchorTile` method to use `Tilemap.getTileAtWorldXY`.

* Remove manual computation of tile coordinates.
* Retrieve the tile at the player's center point using `getTileAtWorldXY`.
* Call `getFirstFilledTileAbove` on the `currentMap` object with the retrieved tile's coordinates.
* Return null if no tile is found at the player's center point.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nl12/pull/110?shareId=310d86c7-bfc8-471a-8e92-6d94cd6810bd).