### PR TITLE
Transition out of the JUMPING state if blocked from below

### DIFF
--- a/src/objects/Player.ts
+++ b/src/objects/Player.ts
@@ -144,19 +144,26 @@ class Player extends Phaser.Physics.Arcade.Sprite {
 			onExecute: (inputs: Inputs) => {
 				if (this.getBody().velocity.y > 0) {
 					this.nextState = PlayerState.FALLING;
+					return;
 				}
-				if (inputs.left && !inputs.right) {
-					this.getBody().setVelocityX(-Player.RUNNING_VELOCITY);
-				} else if (inputs.right && !inputs.left) {
-					this.getBody().setVelocityX(Player.RUNNING_VELOCITY);
-				} else {
-					this.getBody().setVelocityX(0);
+				if (this.getBody().velocity.y === 0 && this.isBlockedFromBelow()) {
+					console.log("!");
+					this.nextState = PlayerState.IDLE;
+					return;
 				}
 				if (inputs.grappling) {
 					this.nextState = PlayerState.GRAPPLING;
+					return;
 				}
-				if (this.isBlockedFromBelow()) {
-					this.nextState = PlayerState.IDLE;
+				if (inputs.left && !inputs.right) {
+					this.getBody().setVelocityX(-Player.RUNNING_VELOCITY);
+					return;
+				} else if (inputs.right && !inputs.left) {
+					this.getBody().setVelocityX(Player.RUNNING_VELOCITY);
+					return;
+				} else {
+					this.getBody().setVelocityX(0);
+					return;
 				}
 			},
 			onExit: (inputs: Inputs) => {},

--- a/src/objects/Player.ts
+++ b/src/objects/Player.ts
@@ -155,6 +155,9 @@ class Player extends Phaser.Physics.Arcade.Sprite {
 				if (inputs.grappling) {
 					this.nextState = PlayerState.GRAPPLING;
 				}
+				if (this.isBlockedFromBelow()) {
+					this.nextState = PlayerState.IDLE;
+				}
 			},
 			onExit: (inputs: Inputs) => {},
 			onCollision: () => {},


### PR DESCRIPTION
Related to #111

Update the `JUMPING` state to transition to `IDLE` if blocked from below.

* Add a check in the `onExecute` method for the `JUMPING` state to see if the player is blocked from below.
* Transition to the `IDLE` state if the player is blocked from below while in the `JUMPING` state.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nl12/pull/112?shareId=c2bf8c4d-6c3e-4e14-9255-213c429b1999).