### PR TITLE
Draw the grappling line while in GRAPPLING state

### DIFF
--- a/src/objects/Player.ts
+++ b/src/objects/Player.ts
@@ -24,6 +24,7 @@ class Player extends Phaser.Physics.Arcade.Sprite {
 	private nextState: PlayerState;
 	private stateText: Phaser.GameObjects.Text;
 	private currentMap: TilemapManager;
+	private grapplingLine: Phaser.GameObjects.Line | null; // P99ee
 
 	static readonly RUNNING_VELOCITY = 150;
 	static readonly GLIDING_VELOCITY = 100;
@@ -39,6 +40,7 @@ class Player extends Phaser.Physics.Arcade.Sprite {
 		super(scene, x, y, "player");
 		this.currentState = PlayerState.IDLE;
 		this.nextState = PlayerState.IDLE;
+		this.grapplingLine = null; // P99ee
 
 		this.scene.add.existing(this);
 		this.scene.physics.add.existing(this);
@@ -223,6 +225,17 @@ class Player extends Phaser.Physics.Arcade.Sprite {
 						1,
 						1,
 					);
+					// Initialize and draw the vertical line
+					this.grapplingLine = this.scene.add.line(
+						this.x,
+						this.y,
+						0,
+						0,
+						0,
+						anchorTile.pixelY + anchorTile.height,
+						0xffffff,
+					);
+					this.grapplingLine.setOrigin(0.5, 0);
 				}
 			},
 			onExecute: (inputs: Inputs) => {
@@ -236,10 +249,24 @@ class Player extends Phaser.Physics.Arcade.Sprite {
 				if (!inputs.grappling) {
 					this.nextState = PlayerState.FALLING;
 				}
+				// Update the position of the vertical line
+				if (this.grapplingLine) {
+					this.grapplingLine.setTo(
+						this.x,
+						this.y,
+						this.x,
+						this.grapplingLine.geom.y2,
+					);
+				}
 			},
 			onExit: (inputs: Inputs) => {
 				// Clear existing tint
 				this.currentMap.layer.setTint(0xffffff, 0, 0);
+				// Remove the vertical line from the scene
+				if (this.grapplingLine) {
+					this.grapplingLine.destroy();
+					this.grapplingLine = null;
+				}
 			},
 			onCollision: () => {},
 		},

--- a/src/objects/Player.ts
+++ b/src/objects/Player.ts
@@ -24,7 +24,7 @@ class Player extends Phaser.Physics.Arcade.Sprite {
 	private nextState: PlayerState;
 	private stateText: Phaser.GameObjects.Text;
 	private currentMap: TilemapManager;
-	private grapplingLine: Phaser.GameObjects.Line | null; // P99ee
+	private grapplingLine: Phaser.GameObjects.Line;
 
 	static readonly RUNNING_VELOCITY = 150;
 	static readonly GLIDING_VELOCITY = 100;
@@ -40,7 +40,6 @@ class Player extends Phaser.Physics.Arcade.Sprite {
 		super(scene, x, y, "player");
 		this.currentState = PlayerState.IDLE;
 		this.nextState = PlayerState.IDLE;
-		this.grapplingLine = null; // P99ee
 
 		this.scene.add.existing(this);
 		this.scene.physics.add.existing(this);
@@ -232,7 +231,7 @@ class Player extends Phaser.Physics.Arcade.Sprite {
 						0,
 						0,
 						0,
-						anchorTile.pixelY + anchorTile.height,
+						anchorTile.pixelY + this.currentMap.tilemap.tileHeight,
 						0xffffff,
 					);
 					this.grapplingLine.setOrigin(0.5, 0);

--- a/src/objects/Player.ts
+++ b/src/objects/Player.ts
@@ -25,7 +25,7 @@ class Player extends Phaser.Physics.Arcade.Sprite {
 	private stateText: Phaser.GameObjects.Text;
 	private currentMap: TilemapManager;
 	private grapplingLine: Phaser.GameObjects.Line;
-
+	private anchorTile: Phaser.Tilemaps.Tile | null = null;
 	static readonly RUNNING_VELOCITY = 150;
 	static readonly GLIDING_VELOCITY = 100;
 	static readonly JUMPING_VELOCITY = 300;
@@ -214,13 +214,13 @@ class Player extends Phaser.Physics.Arcade.Sprite {
 		[PlayerState.GRAPPLING]: {
 			onEnter: (inputs: Inputs) => {
 				this.getBody().setVelocityX(0);
-				const anchorTile = this.getGrapplingHookAnchorTile();
-				if (anchorTile) {
+				this.anchorTile = this.getGrapplingHookAnchorTile();
+				if (this.anchorTile) {
 					// Tint the anchor tile
 					this.currentMap.layer.setTint(
 						0xff00ff,
-						anchorTile.x,
-						anchorTile.y,
+						this.anchorTile.x,
+						this.anchorTile.y,
 						1,
 						1,
 					);
@@ -231,9 +231,10 @@ class Player extends Phaser.Physics.Arcade.Sprite {
 						0,
 						0,
 						0,
-						anchorTile.pixelY + this.currentMap.tilemap.tileHeight,
+						this.anchorTile.pixelY - this.y + this.height,
 						0xffffff,
 					);
+					this.grapplingLine.setLineWidth(5);
 					this.grapplingLine.setOrigin(0.5, 0);
 				}
 			},
@@ -249,12 +250,13 @@ class Player extends Phaser.Physics.Arcade.Sprite {
 					this.nextState = PlayerState.FALLING;
 				}
 				// Update the position of the vertical line
-				if (this.grapplingLine) {
+				if (this.grapplingLine && this.anchorTile) {
+					this.grapplingLine.setPosition(this.x, this.y);
 					this.grapplingLine.setTo(
-						this.x,
-						this.y,
-						this.x,
-						this.grapplingLine.geom.y2,
+						0,
+						0,
+						0,
+						this.anchorTile.pixelY - this.y + this.height,
 					);
 				}
 			},


### PR DESCRIPTION
Related to #113

Add a grappling line while in the GRAPPLING state.

* Add a `grapplingLine` property to the `Player` class to store the line object.
* Initialize and draw the vertical line in the `onEnter` method of the `GRAPPLING` state.
* Update the position of the vertical line in the `onExecute` method of the `GRAPPLING` state.
* Remove the vertical line from the scene in the `onExit` method of the `GRAPPLING` state.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nl12/pull/114?shareId=b50fca7a-aa9c-4865-a3ce-2d1ebd804412).