### PR TITLE
Tween the deployment and retraction of the grappling hook line

### DIFF
--- a/src/objects/Player.ts
+++ b/src/objects/Player.ts
@@ -2,7 +2,6 @@ import Phaser from "phaser";
 import TextureGenerator from "../utils/TextureGenerator";
 import { Inputs } from "../utils/InputManager";
 import TilemapManager from "../utils/TilemapManager";
-import { Tweens } from "phaser"; // Import Phaser.Tweens
 
 enum PlayerState {
 	IDLE,

--- a/src/objects/Player.ts
+++ b/src/objects/Player.ts
@@ -234,13 +234,14 @@ class Player extends Phaser.Physics.Arcade.Sprite {
 						this.anchorTile.pixelY - this.y + this.height,
 						0xffffff,
 					);
+					this.grapplingLine.setScale(1, 0);
 					this.grapplingLine.setLineWidth(5);
 					this.grapplingLine.setOrigin(0.5, 0);
 					// Add a tween to scale the grappling line from 0.5% to 100%
 					this.scene.tweens.add({
 						targets: this.grapplingLine,
-						scaleY: { from: 0.005, to: 1 },
-						duration: 200,
+						scaleY: { from: 0.0, to: 1 },
+						duration: 25,
 					});
 				}
 			},
@@ -273,8 +274,8 @@ class Player extends Phaser.Physics.Arcade.Sprite {
 				if (this.grapplingLine) {
 					this.scene.tweens.add({
 						targets: this.grapplingLine,
-						scaleY: { from: 1, to: 0.005 },
-						duration: 200,
+						scaleY: { from: 1, to: 0 },
+						duration: 25,
 						onComplete: () => {
 							this.grapplingLine.destroy();
 							this.grapplingLine = null;

--- a/src/objects/Player.ts
+++ b/src/objects/Player.ts
@@ -2,6 +2,7 @@ import Phaser from "phaser";
 import TextureGenerator from "../utils/TextureGenerator";
 import { Inputs } from "../utils/InputManager";
 import TilemapManager from "../utils/TilemapManager";
+import { Tweens } from "phaser"; // Import Phaser.Tweens
 
 enum PlayerState {
 	IDLE,
@@ -236,6 +237,12 @@ class Player extends Phaser.Physics.Arcade.Sprite {
 					);
 					this.grapplingLine.setLineWidth(5);
 					this.grapplingLine.setOrigin(0.5, 0);
+					// Add a tween to scale the grappling line from 0.5% to 100%
+					this.scene.tweens.add({
+						targets: this.grapplingLine,
+						scaleY: { from: 0.005, to: 1 },
+						duration: 200,
+					});
 				}
 			},
 			onExecute: (inputs: Inputs) => {
@@ -263,10 +270,17 @@ class Player extends Phaser.Physics.Arcade.Sprite {
 			onExit: (inputs: Inputs) => {
 				// Clear existing tint
 				this.currentMap.layer.setTint(0xffffff, 0, 0);
-				// Remove the vertical line from the scene
+				// Add a tween to scale the grappling line from 100% to 0.5% before destroying it
 				if (this.grapplingLine) {
-					this.grapplingLine.destroy();
-					this.grapplingLine = null;
+					this.scene.tweens.add({
+						targets: this.grapplingLine,
+						scaleY: { from: 1, to: 0.005 },
+						duration: 200,
+						onComplete: () => {
+							this.grapplingLine.destroy();
+							this.grapplingLine = null;
+						},
+					});
 				}
 			},
 			onCollision: () => {},


### PR DESCRIPTION
Related to #115

Add tweening to the deployment and retraction of the grappling hook line.

* Import `Phaser.Tweens` in `src/objects/Player.ts`.
* In the `onEnter` method of the `GRAPPLING` state, add a tween to scale the grappling line from 0.5% to 100%.
* In the `onExit` method of the `GRAPPLING` state, add a tween to scale the grappling line from 100% to 0.5% before destroying it.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nl12/pull/116?shareId=38042eee-004d-4bf4-baeb-729eb7030063).