### PR TITLE
Refactor texture management to use a single module

### DIFF
--- a/src/objects/Player.ts
+++ b/src/objects/Player.ts
@@ -1,5 +1,5 @@
 import Phaser from "phaser";
-import TextureGenerator from "../utils/TextureGenerator";
+import TextureManager from "../utils/TextureManager";
 import { Inputs } from "../utils/InputManager";
 import TilemapManager from "../utils/TilemapManager";
 
@@ -44,7 +44,7 @@ class Player extends Phaser.Physics.Arcade.Sprite {
 		this.scene.add.existing(this);
 		this.scene.physics.add.existing(this);
 
-		TextureGenerator.generateTexture(scene, 0x0000ff, width, height, "player", {
+		TextureManager.generateTextureIfNotExists(scene, 0x0000ff, width, height, "player", {
 			color: 0xff0000,
 			thickness: 5,
 		});

--- a/src/utils/TextureManager.ts
+++ b/src/utils/TextureManager.ts
@@ -1,0 +1,40 @@
+import Phaser from "phaser";
+import TextureGenerator from "./TextureGenerator";
+
+class TextureManager {
+  static readonly Textures = {
+    PLAYER: "player",
+    EMPTY_TILE: "empty",
+    FILLED_TILE: "filled",
+  };
+
+  static generateTextureIfNotExists(
+    scene: Phaser.Scene,
+    color: number,
+    width: number,
+    height: number,
+    name: string,
+    border?: { color: number; thickness: number }
+  ) {
+    if (!scene.textures.exists(name)) {
+      TextureGenerator.generateTexture(scene, color, width, height, name, border);
+    }
+  }
+
+  static generateAllTextures(scene: Phaser.Scene, width: number, height: number) {
+    this.generateTextureIfNotExists(scene, 0x0000ff, width, height, this.Textures.PLAYER, {
+      color: 0xff0000,
+      thickness: 5,
+    });
+    this.generateTextureIfNotExists(scene, 0x000000, width, height, this.Textures.EMPTY_TILE, {
+      color: 0x000000,
+      thickness: 1,
+    });
+    this.generateTextureIfNotExists(scene, 0xf0aa00, width, height, this.Textures.FILLED_TILE, {
+      color: 0xf0ee00,
+      thickness: 1,
+    });
+  }
+}
+
+export default TextureManager;

--- a/src/utils/TilemapManager.ts
+++ b/src/utils/TilemapManager.ts
@@ -1,5 +1,5 @@
 import Phaser from "phaser";
-import TextureGenerator from "./TextureGenerator";
+import TextureManager from "./TextureManager";
 
 class TilemapManager {
 	scene: Phaser.Scene;
@@ -17,22 +17,7 @@ class TilemapManager {
 		tileWidth: number,
 		tileHeight: number,
 	) {
-		TextureGenerator.generateTexture(
-			scene,
-			0x000000,
-			tileWidth,
-			tileHeight,
-			"empty",
-			{ color: 0x000000, thickness: 1 },
-		);
-		TextureGenerator.generateTexture(
-			scene,
-			0xf0aa00,
-			tileWidth,
-			tileHeight,
-			"filled",
-			{ color: 0xf0ee00, thickness: 1 },
-		);
+		TextureManager.generateAllTextures(scene, tileWidth, tileHeight);
 
 		this.tilemap = scene.make.tilemap({
 			width,
@@ -41,7 +26,7 @@ class TilemapManager {
 			tileHeight,
 		});
 		this.filledTileset = this.tilemap.addTilesetImage(
-			"filled",
+			TextureManager.FILLED_TILE_TEXTURE,
 			undefined,
 			tileWidth,
 			tileHeight,
@@ -54,7 +39,7 @@ class TilemapManager {
 		}
 
 		this.emptyTileset = this.tilemap.addTilesetImage(
-			"empty",
+			TextureManager.EMPTY_TILE_TEXTURE,
 			undefined,
 			tileWidth,
 			tileHeight,


### PR DESCRIPTION
Related to #117

Move texture generation out of the MapManager and Player classes into a separate module.

* Add `src/utils/TextureManager.ts` to handle texture generation and storage.
* Modify `src/objects/Player.ts` to use `TextureManager` for player texture instead of generating it.
* Modify `src/utils/TilemapManager.ts` to use `TextureManager` for empty and filled tile textures instead of generating them.
* Remove calls to `TextureGenerator.generateTexture` in `Player` and `TilemapManager` classes.
* Add constants for texture names in `TextureManager` to be referenced by other classes.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nl12/pull/118?shareId=12d2d24a-83fe-488c-b5bc-04306f732c1c).