### PR TITLE
Add more variation to the filled tile type

### DIFF
--- a/src/utils/TextureGenerator.ts
+++ b/src/utils/TextureGenerator.ts
@@ -13,10 +13,25 @@ class TextureGenerator {
 		height: number,
 		name: string,
 		border?: Border,
+		numSquares: number = 1,
 	) {
 		const graphics = scene.add.graphics();
-		graphics.fillStyle(color, 1);
-		graphics.fillRect(0, 0, width, height);
+		const squareWidth = width / numSquares;
+		const squareHeight = height / numSquares;
+
+		for (let i = 0; i < numSquares; i++) {
+			for (let j = 0; j < numSquares; j++) {
+				const shade = Phaser.Display.Color.Interpolate.ColorWithColor(
+					Phaser.Display.Color.ValueToColor(color),
+					Phaser.Display.Color.ValueToColor(0xffffff),
+					numSquares,
+					i + j,
+				);
+				const fillColor = Phaser.Display.Color.GetColor(shade.r, shade.g, shade.b);
+				graphics.fillStyle(fillColor, 1);
+				graphics.fillRect(i * squareWidth, j * squareHeight, squareWidth, squareHeight);
+			}
+		}
 
 		if (border) {
 			graphics.lineStyle(border.thickness, border.color, 1);

--- a/src/utils/TextureManager.ts
+++ b/src/utils/TextureManager.ts
@@ -21,7 +21,7 @@ class TextureManager {
     }
   }
 
-  static generateAllTextures(scene: Phaser.Scene, width: number, height: number) {
+  static generateAllTextures(scene: Phaser.Scene, width: number, height: number, numSquares: number = 1) {
     this.generateTextureIfNotExists(scene, 0x0000ff, width, height, this.Textures.PLAYER, {
       color: 0xff0000,
       thickness: 5,
@@ -33,7 +33,7 @@ class TextureManager {
     this.generateTextureIfNotExists(scene, 0xf0aa00, width, height, this.Textures.FILLED_TILE, {
       color: 0xf0ee00,
       thickness: 1,
-    });
+    }, numSquares);
   }
 }
 

--- a/src/utils/TilemapManager.ts
+++ b/src/utils/TilemapManager.ts
@@ -16,8 +16,9 @@ class TilemapManager {
 		height: number,
 		tileWidth: number,
 		tileHeight: number,
+		numSquares: number = 1,
 	) {
-		TextureManager.generateAllTextures(scene, tileWidth, tileHeight);
+		TextureManager.generateAllTextures(scene, tileWidth, tileHeight, numSquares);
 
 		this.tilemap = scene.make.tilemap({
 			width,
@@ -73,7 +74,11 @@ class TilemapManager {
 		layer: Phaser.Tilemaps.TilemapLayer;
 		filledTileset: Phaser.Tilemaps.Tileset;
 	}) {
-		layer.setCollision(filledTileset.firstgid);
+		const filledGIDs = [];
+		for (let i = 0; i < filledTileset.total; i++) {
+			filledGIDs.push(filledTileset.firstgid + i);
+		}
+		layer.setCollision(filledGIDs);
 	}
 
 	public setTile(x: number, y: number, filled: boolean) {
@@ -118,7 +123,7 @@ class TilemapManager {
 		const startTile = this.layer.getTileAtWorldXY(worldX, worldY);
 		for (let ty = startTile.y - 1; ty >= 0; ty--) {
 			const tile = this.tilemap.getTileAt(startTile.x, ty);
-			if (tile && tile.index === this.filledTileset.firstgid) {
+			if (tile && tile.index >= this.filledTileset.firstgid && tile.index < this.filledTileset.firstgid + this.filledTileset.total) {
 				return tile;
 			}
 		}


### PR DESCRIPTION
Related to #119

Add variation to filled tile type by generating multiple filled squares with gradient dithering patterns.

* Update `generateTexture` method in `src/utils/TextureGenerator.ts` to accept `numSquares` parameter and generate multiple filled squares with gradient dithering patterns.
* Update `createTilemap` method in `src/utils/TilemapManager.ts` to use `numSquares` parameter to generate multi-square texture.
* Update `setupCollision` method in `src/utils/TilemapManager.ts` to handle multiple GIDs for collision.
* Update `getFirstFilledTileAbove` method in `src/utils/TilemapManager.ts` to check for all GIDs in the range of filled tiles.
* Update `generateAllTextures` method in `src/utils/TextureManager.ts` to generate filled tile texture with variation using `numSquares` parameter.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nl12/pull/121?shareId=c9fceff9-815f-407c-b67f-3ebf8afe2534).