### PR TITLE
Lay groundwork for variations texture to be used for filled tiles in the MapManager

### DIFF
--- a/src/utils/TextureManager.ts
+++ b/src/utils/TextureManager.ts
@@ -53,7 +53,7 @@ class TextureManager {
 
     for (let i = 0; i < count; i++) {
       const variation = Phaser.Math.Between(-variationRange, variationRange);
-      const variedColor = Phaser.Display.Color.HSVColorWheel()[baseColor.h + variation];
+      const variedColor = Phaser.Display.Color.HSVColorWheel()[Math.round(baseColor.h) + variation];
       graphics.fillStyle(variedColor.color, 1);
       graphics.fillRect(i * width, 0, width, height);
 

--- a/src/utils/TextureManager.ts
+++ b/src/utils/TextureManager.ts
@@ -7,18 +7,6 @@ class TextureManager {
     FILLED_TILE: "filled",
   };
 
-  static generateTextureIfNotExists(
-    scene: Phaser.Scene,
-    color: number,
-    width: number,
-    height: number,
-    name: string,
-    border?: { color: number; thickness: number }
-  ) {
-    if (!scene.textures.exists(name)) {
-      this.generateTexture(scene, color, width, height, name, border);
-    }
-  }
 
   static generateAllTextures(scene: Phaser.Scene, width: number, height: number) {
     this.generateTextureIfNotExists(scene, 0x0000ff, width, height, this.Textures.PLAYER, {
@@ -35,24 +23,47 @@ class TextureManager {
     });
   }
 
+  static generateTextureIfNotExists(
+    scene: Phaser.Scene,
+    color: number,
+    width: number,
+    height: number,
+    name: string,
+    border?: { color: number; thickness: number },
+    count: number = 1,
+    variationRange: number = 0
+  ) {
+    if (!scene.textures.exists(name)) {
+      this.generateTexture(scene, color, width, height, name, border, count, variationRange);
+    }
+  }
+
   static generateTexture(
     scene: Phaser.Scene,
     color: number,
     width: number,
     height: number,
     name: string,
-    border?: { color: number; thickness: number }
+    border?: { color: number; thickness: number },
+    count: number = 1,
+    variationRange: number = 0
   ) {
     const graphics = scene.add.graphics();
-    graphics.fillStyle(color, 1);
-    graphics.fillRect(0, 0, width, height);
+    const baseColor = Phaser.Display.Color.IntegerToColor(color);
 
-    if (border) {
-      graphics.lineStyle(border.thickness, border.color, 1);
-      graphics.strokeRect(0, 0, width, height);
+    for (let i = 0; i < count; i++) {
+      const variation = Phaser.Math.Between(-variationRange, variationRange);
+      const variedColor = Phaser.Display.Color.HSVColorWheel()[baseColor.h + variation];
+      graphics.fillStyle(variedColor.color, 1);
+      graphics.fillRect(i * width, 0, width, height);
+
+      if (border) {
+        graphics.lineStyle(border.thickness, border.color, 1);
+        graphics.strokeRect(i * width, 0, width, height);
+      }
     }
 
-    graphics.generateTexture(name, width, height);
+    graphics.generateTexture(name, width * count, height);
     graphics.destroy();
   }
 }


### PR DESCRIPTION
Related to #125

Modify the `generateTexture` method in `src/utils/TextureManager.ts` to render a row of 'count' rectangles of the specified width and height with each being a slight variation of the specified color.

* Add parameters `count` and `variationRange` to the `generateTexture` method.
* Adjust the color variations by slightly modifying the hue, saturation, or brightness of the base color.
* Update the `generateTextureIfNotExists` method to include the new parameters `count` and `variationRange`.
* Generate the texture with the specified number of rectangles and color variations.
* Adjust the texture dimensions to accommodate the row of rectangles.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nl12/pull/126?shareId=d95fd5d0-76cd-420f-8298-e3a63a8fd38f).