### PR TITLE
Add variation to generated textures if the count value > 1

### DIFF
--- a/src/utils/TextureManager.ts
+++ b/src/utils/TextureManager.ts
@@ -24,7 +24,7 @@ class TextureManager {
 			name: "filled",
 			height: 25,
 			width: 25,
-			count: 1,
+			count: 10,
 			color: 0xf0aa00,
 			margin: 0,
 			spacing: 0,
@@ -67,9 +67,12 @@ class TextureManager {
 		},
 	) {
 		const graphics = scene.add.graphics();
-		graphics.fillStyle(texture.color, 1);
 
 		for (let i = 0; i < texture.count; i++) {
+			const variation = Phaser.Display.Color.IntegerToColor(texture.color).clone();
+			variation.darken(i * 5); // Slightly darken each subsequent rectangle
+			graphics.fillStyle(variation.color, 1);
+
 			const x = texture.margin + i * (texture.width + texture.spacing);
 			graphics.fillRect(x, texture.margin, texture.width, texture.height);
 		}

--- a/src/utils/TilemapManager.ts
+++ b/src/utils/TilemapManager.ts
@@ -73,12 +73,16 @@ class TilemapManager {
 		layer: Phaser.Tilemaps.TilemapLayer;
 		filledTileset: Phaser.Tilemaps.Tileset;
 	}) {
-		layer.setCollision(filledTileset.firstgid);
+		const filledTileGIDs = Array.from(
+			{ length: TextureManager.Textures.FILLED_TILE.count },
+			(_, i) => filledTileset.firstgid + i
+		);
+		layer.setCollision(filledTileGIDs);
 	}
 
 	public setTile(x: number, y: number, filled: boolean) {
 		const tileIndex = filled
-			? this.filledTileset.firstgid
+			? this.filledTileset.firstgid + Math.floor(Math.random() * TextureManager.Textures.FILLED_TILE.count)
 			: this.emptyTileset.firstgid;
 		this.tilemap.putTileAt(tileIndex, x, y, true, this.layer);
 	}
@@ -118,7 +122,7 @@ class TilemapManager {
 		const startTile = this.layer.getTileAtWorldXY(worldX, worldY);
 		for (let ty = startTile.y - 1; ty >= 0; ty--) {
 			const tile = this.tilemap.getTileAt(startTile.x, ty);
-			if (tile && tile.index === this.filledTileset.firstgid) {
+			if (tile && tile.index >= this.filledTileset.firstgid && tile.index < this.filledTileset.firstgid + TextureManager.Textures.FILLED_TILE.count) {
 				return tile;
 			}
 		}


### PR DESCRIPTION
Related to #130

Introduce color variations for generated textures and update tilemap logic.

* Update `generateTexture` method in `src/utils/TextureManager.ts` to introduce slight color variations for subsequent rectangles when `count` is greater than 1.
* Set `count` to 10 for `FILLED_TILE` in `Textures` object.
* Update `populateTilemap` method in `src/utils/TilemapManager.ts` to randomly pick a filled tile from the available set when placing a filled tile.
* Ensure the full range of GIDs is used for tileset images using `TextureManager.Textures` texture that have a count > 1.
* Update `setupCollision` method to account for tilesets that have more than 1 tile.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nl12/pull/131?shareId=c476e032-14c8-4625-9a35-5e3bca1cae75).