### PR TITLE
Add variation to generated textures if the count value > 1

### DIFF
--- a/src/utils/TextureManager.ts
+++ b/src/utils/TextureManager.ts
@@ -24,7 +24,7 @@ class TextureManager {
 			name: "filled",
 			height: 25,
 			width: 25,
-			count: 1,
+			count: 10,
 			color: 0xf0aa00,
 			margin: 0,
 			spacing: 0,
@@ -67,9 +67,12 @@ class TextureManager {
 		},
 	) {
 		const graphics = scene.add.graphics();
-		graphics.fillStyle(texture.color, 1);
 
 		for (let i = 0; i < texture.count; i++) {
+			const variation = i === 0 ? 0 : Phaser.Math.Between(-10, 10);
+			const color = Phaser.Display.Color.IntegerToColor(texture.color).brighten(variation).color;
+			graphics.fillStyle(color, 1);
+
 			const x = texture.margin + i * (texture.width + texture.spacing);
 			graphics.fillRect(x, texture.margin, texture.width, texture.height);
 		}


### PR DESCRIPTION
Related to #130

Add texture variation and update tile count for filled tiles.

* **Texture Variation**: Add logic in `src/utils/TextureManager.ts` to apply slight color/texture variation for textures with `count` greater than 1.
* **Tile Count**: Update `FILLED_TILE` texture `count` to 10 in `src/utils/TextureManager.ts`.
* **Starting GID**: Update `createTilemap` in `src/utils/TilemapManager.ts` to set the starting GID to account for previously created tilesetImages and number of tiles contained. Add a running count of the starting GID to avoid computing each time.
* **Tile Selection**: Update `populateTilemap` in `src/utils/TilemapManager.ts` to randomly pick a tile from the appropriate tileset image.
* **Collision and Anchor Tile Computations**: Update `setupCollision` in `src/utils/TilemapManager.ts` to use the full range of GIDs for collisions and anchor tile computations, using the tileset images 'total' property.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nl12/pull/133?shareId=4afa43e9-82cd-40b4-a72f-b26744aef43a).