### PR TITLE
Add optional value noise to generated textures

### DIFF
--- a/src/utils/TextureManager.ts
+++ b/src/utils/TextureManager.ts
@@ -10,6 +10,7 @@ class TextureManager {
 			color: 0x0000ff,
 			margin: 0,
 			spacing: 0,
+			noise: false,
 		},
 		EMPTY_TILE: {
 			name: "empty",
@@ -19,6 +20,7 @@ class TextureManager {
 			color: 0x000000,
 			margin: 0,
 			spacing: 0,
+			noise: false,
 		},
 		FILLED_TILE: {
 			name: "filled",
@@ -28,6 +30,7 @@ class TextureManager {
 			color: 0xf0aa00,
 			margin: 0,
 			spacing: 0,
+			noise: true,
 		},
 	};
 
@@ -41,6 +44,7 @@ class TextureManager {
 			color: number;
 			margin: number;
 			spacing: number;
+			noise: boolean;
 		},
 	) {
 		if (!scene.textures.exists(texture.name)) {
@@ -64,6 +68,7 @@ class TextureManager {
 			color: number;
 			margin: number;
 			spacing: number;
+			noise: boolean;
 		},
 	) {
 		const graphics = scene.add.graphics();
@@ -75,6 +80,10 @@ class TextureManager {
 
 			const x = texture.margin + i * (texture.width + texture.spacing);
 			graphics.fillRect(x, texture.margin, texture.width, texture.height);
+
+			if (texture.noise) {
+				this.applyValueNoise(graphics, x, texture.margin, texture.width, texture.height);
+			}
 		}
 
 		graphics.generateTexture(
@@ -85,6 +94,24 @@ class TextureManager {
 			texture.height + texture.margin * 2,
 		);
 		graphics.destroy();
+	}
+
+	static applyValueNoise(graphics: Phaser.GameObjects.Graphics, x: number, y: number, width: number, height: number) {
+		const noiseScale = 0.1;
+		const noise = new Array(width * height).fill(0).map((_, i) => {
+			const nx = (i % width) * noiseScale;
+			const ny = Math.floor(i / width) * noiseScale;
+			return Phaser.Math.PerlinNoise(nx, ny);
+		});
+
+		for (let i = 0; i < noise.length; i++) {
+			const nx = i % width;
+			const ny = Math.floor(i / width);
+			const brightness = Phaser.Math.Clamp(noise[i] * 255, 0, 255);
+			const color = Phaser.Display.Color.GetColor(brightness, brightness, brightness);
+			graphics.fillStyle(color, 0.1);
+			graphics.fillRect(x + nx, y + ny, 1, 1);
+		}
 	}
 }
 

--- a/src/utils/TextureManager.ts
+++ b/src/utils/TextureManager.ts
@@ -101,7 +101,7 @@ class TextureManager {
 		const noise = new Array(width * height).fill(0).map((_, i) => {
 			const nx = (i % width) * noiseScale;
 			const ny = Math.floor(i / width) * noiseScale;
-			return Phaser.Math.PerlinNoise(nx, ny);
+			return this.customValueNoise(nx, ny);
 		});
 
 		for (let i = 0; i < noise.length; i++) {
@@ -112,6 +112,11 @@ class TextureManager {
 			graphics.fillStyle(color, 0.1);
 			graphics.fillRect(x + nx, y + ny, 1, 1);
 		}
+	}
+
+	static customValueNoise(x: number, y: number): number {
+		const n = Math.sin(x * 12.9898 + y * 78.233) * 43758.5453;
+		return n - Math.floor(n);
 	}
 }
 


### PR DESCRIPTION
Related to #134

Add optional noise to generated textures.

* Add a `noise` field to the `Textures` structure in `src/utils/TextureManager.ts`.
* Update the `generateTexture` method to add value noise to the filled rectangles if the `noise` field is set to true.
* Implement the `applyValueNoise` method to generate and apply value noise to the filled rectangles.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nl12/pull/135?shareId=17058c16-154e-4641-b88a-7a96b0ff6b87).