### PR TITLE
Add loot to the map

### DIFF
--- a/src/objects/Player.ts
+++ b/src/objects/Player.ts
@@ -291,6 +291,13 @@ class Player extends Phaser.Physics.Arcade.Sprite {
 		this.stateMachine[this.currentState].onCollision();
 	}
 
+	handleLootCollision(tile: Phaser.Tilemaps.Tile) {
+		if (tile.index === this.currentMap.lootTileset.firstgid) {
+			this.currentMap.layer.removeTileAt(tile.x, tile.y);
+			console.log("Loot collected!");
+		}
+	}
+
 	public updateState(inputs: Inputs) {
 		if (this.nextState !== this.currentState) {
 			this.stateMachine[this.currentState].onExit(inputs);

--- a/src/scenes/PlayScene.ts
+++ b/src/scenes/PlayScene.ts
@@ -35,6 +35,7 @@ class PlayScene extends Phaser.Scene {
 			Config.TileHeight,
 		);
 		tilemapManager.populateTilemap(map);
+		tilemapManager.scatterLoot();
 		this.physics.world.setBounds(
 			0,
 			0,
@@ -61,6 +62,13 @@ class PlayScene extends Phaser.Scene {
 				undefined,
 				this,
 			);
+			this.physics.add.collider(
+				this.player,
+				tilemapManager.layer,
+				this.handleLootCollision,
+				undefined,
+				this,
+			);
 			this.player.setCurrentMap(tilemapManager);
 		}
 	}
@@ -75,6 +83,13 @@ class PlayScene extends Phaser.Scene {
 
 	private handlePlayerCollision(player: any, tile: any) {
 		(player as Player).handleCollision();
+	}
+
+	private handleLootCollision(player: any, tile: any) {
+		if (tile.index === tilemapManager.lootTileset.firstgid) {
+			tilemapManager.layer.removeTileAt(tile.x, tile.y);
+			console.log("Loot collected!");
+		}
 	}
 }
 

--- a/src/utils/TextureManager.ts
+++ b/src/utils/TextureManager.ts
@@ -32,6 +32,16 @@ class TextureManager {
 			spacing: 0,
 			noise: true,
 		},
+		LOOT: {
+			name: "loot",
+			height: 25,
+			width: 25,
+			count: 1,
+			color: 0x00ff00,
+			margin: 0,
+			spacing: 0,
+			noise: false,
+		},
 	};
 
 	static generateTextureIfNotExists(
@@ -56,6 +66,7 @@ class TextureManager {
 		this.generateTextureIfNotExists(scene, this.Textures.PLAYER);
 		this.generateTextureIfNotExists(scene, this.Textures.EMPTY_TILE);
 		this.generateTextureIfNotExists(scene, this.Textures.FILLED_TILE);
+		this.generateTextureIfNotExists(scene, this.Textures.LOOT);
 	}
 
 	static generateTexture(

--- a/src/utils/TilemapManager.ts
+++ b/src/utils/TilemapManager.ts
@@ -6,6 +6,7 @@ class TilemapManager {
 	tilemap: Phaser.Tilemaps.Tilemap;
 	emptyTileset: Phaser.Tilemaps.Tileset;
 	filledTileset: Phaser.Tilemaps.Tileset;
+	lootTileset: Phaser.Tilemaps.Tileset;
 	layer: Phaser.Tilemaps.TilemapLayer;
 	startingGID: number = 1;
 
@@ -54,9 +55,24 @@ class TilemapManager {
 		}
 		this.startingGID += this.emptyTileset.total;
 
+		this.lootTileset = this.tilemap.addTilesetImage(
+			TextureManager.Textures.LOOT.name,
+			undefined,
+			TextureManager.Textures.LOOT.width,
+			TextureManager.Textures.LOOT.height,
+			TextureManager.Textures.LOOT.margin,
+			TextureManager.Textures.LOOT.spacing,
+			this.startingGID,
+		);
+		if (!this.lootTileset) {
+			throw new Error("Failed to create 'loot' TilesetImage");
+		}
+		this.startingGID += this.lootTileset.total;
+
 		this.layer = this.tilemap.createBlankLayer("layer", [
 			this.emptyTileset,
 			this.filledTileset,
+			this.lootTileset,
 		]);
 
 		if (!this.layer) {
@@ -98,6 +114,15 @@ class TilemapManager {
 		for (let y = 0; y < map.length; y++) {
 			for (let x = 0; x < map[y].length; x++) {
 				this.setTile(x, y, map[y][x]);
+			}
+		}
+	}
+
+	public scatterLoot() {
+		for (let i = 0; i < 10; i++) {
+			const tile = this.findRandomNonFilledTile();
+			if (tile) {
+				this.tilemap.putTileAt(this.lootTileset.firstgid, tile.x, tile.y, true, this.layer);
 			}
 		}
 	}


### PR DESCRIPTION
Related to #136

Add loot to the map and handle collision with the player.

* Add a new `Textures` entry for LOOT colored green without noise in `src/utils/TextureManager.ts`.
* Create a tilesetImage for the loot and add a method to scatter 10 pieces of loot throughout the map in `src/utils/TilemapManager.ts`.
* Add a collider for the LOOT tiles and handle loot collision in `src/scenes/PlayScene.ts`.
* Add code to remove the loot tile and log to console on collision in `src/objects/Player.ts`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nl12/pull/137?shareId=669639e9-fdb2-4123-8b29-d1144d7b41f7).