### PR TITLE
Add loot to the map

### DIFF
--- a/src/objects/Player.ts
+++ b/src/objects/Player.ts
@@ -288,6 +288,11 @@ class Player extends Phaser.Physics.Arcade.Sprite {
 	};
 
 	handleCollision() {
+		const tile = this.currentMap.tilemap.getTileAtWorldXY(this.x, this.y);
+		if (tile && tile.properties.loot) {
+			this.currentMap.tilemap.removeTileAt(tile.x, tile.y);
+			console.log("Loot collected!");
+		}
 		this.stateMachine[this.currentState].onCollision();
 	}
 

--- a/src/scenes/PlayScene.ts
+++ b/src/scenes/PlayScene.ts
@@ -62,6 +62,7 @@ class PlayScene extends Phaser.Scene {
 				this,
 			);
 			this.player.setCurrentMap(tilemapManager);
+			this.scatterLoot(tilemapManager, 10);
 		}
 	}
 
@@ -75,6 +76,15 @@ class PlayScene extends Phaser.Scene {
 
 	private handlePlayerCollision(player: any, tile: any) {
 		(player as Player).handleCollision();
+	}
+
+	private scatterLoot(tilemapManager: TilemapManager, count: number) {
+		for (let i = 0; i < count; i++) {
+			const lootPosition = tilemapManager.findRandomNonFilledTile();
+			if (lootPosition) {
+				tilemapManager.setTile(lootPosition.x, lootPosition.y, false, true);
+			}
+		}
 	}
 }
 

--- a/src/utils/TextureManager.ts
+++ b/src/utils/TextureManager.ts
@@ -32,6 +32,16 @@ class TextureManager {
 			spacing: 0,
 			noise: true,
 		},
+		LOOT: {
+			name: "loot",
+			height: 25,
+			width: 25,
+			count: 1,
+			color: 0x00ff00,
+			margin: 0,
+			spacing: 0,
+			noise: false,
+		},
 	};
 
 	static generateTextureIfNotExists(
@@ -56,6 +66,7 @@ class TextureManager {
 		this.generateTextureIfNotExists(scene, this.Textures.PLAYER);
 		this.generateTextureIfNotExists(scene, this.Textures.EMPTY_TILE);
 		this.generateTextureIfNotExists(scene, this.Textures.FILLED_TILE);
+		this.generateTextureIfNotExists(scene, this.Textures.LOOT);
 	}
 
 	static generateTexture(

--- a/src/utils/TilemapManager.ts
+++ b/src/utils/TilemapManager.ts
@@ -6,6 +6,7 @@ class TilemapManager {
 	tilemap: Phaser.Tilemaps.Tilemap;
 	emptyTileset: Phaser.Tilemaps.Tileset;
 	filledTileset: Phaser.Tilemaps.Tileset;
+	lootTileset: Phaser.Tilemaps.Tileset;
 	layer: Phaser.Tilemaps.TilemapLayer;
 	startingGID: number = 1;
 
@@ -54,9 +55,24 @@ class TilemapManager {
 		}
 		this.startingGID += this.emptyTileset.total;
 
+		this.lootTileset = this.tilemap.addTilesetImage(
+			TextureManager.Textures.LOOT.name,
+			undefined,
+			TextureManager.Textures.LOOT.width,
+			TextureManager.Textures.LOOT.height,
+			TextureManager.Textures.LOOT.margin,
+			TextureManager.Textures.LOOT.spacing,
+			this.startingGID,
+		);
+		if (!this.lootTileset) {
+			throw new Error("Failed to create 'loot' TilesetImage");
+		}
+		this.startingGID += this.lootTileset.total;
+
 		this.layer = this.tilemap.createBlankLayer("layer", [
 			this.emptyTileset,
 			this.filledTileset,
+			this.lootTileset,
 		]);
 
 		if (!this.layer) {
@@ -84,14 +100,22 @@ class TilemapManager {
 		layer.setCollision(filledTileRange);
 	}
 
-	public setTile(x: number, y: number, filled: boolean) {
-		const tileIndex = filled
-			? Phaser.Math.Between(
-					this.filledTileset.firstgid,
-					this.filledTileset.firstgid + this.filledTileset.total - 1,
-				)
-			: this.emptyTileset.firstgid;
-		this.tilemap.putTileAt(tileIndex, x, y, true, this.layer);
+	public setTile(x: number, y: number, filled: boolean, loot: boolean = false) {
+		let tileIndex;
+		if (loot) {
+			tileIndex = this.lootTileset.firstgid;
+		} else {
+			tileIndex = filled
+				? Phaser.Math.Between(
+						this.filledTileset.firstgid,
+						this.filledTileset.firstgid + this.filledTileset.total - 1,
+					)
+				: this.emptyTileset.firstgid;
+		}
+		const tile = this.tilemap.putTileAt(tileIndex, x, y, true, this.layer);
+		if (loot) {
+			tile.properties.loot = true;
+		}
 	}
 
 	public populateTilemap(map: boolean[][]) {


### PR DESCRIPTION
Related to #136

Add loot to the map and handle player collision with loot.

* Add a new Textures entry for LOOT colored green without noise in `src/utils/TextureManager.ts`.
* Create a tilesetImage for the loot in `src/utils/TilemapManager.ts`.
* Set a property indicating that a tile is loot when adding it to the tilemap in `src/utils/TilemapManager.ts`.
* Check for the loot property in the Player onCollision callback and remove the tile from the map if it is loot in `src/objects/Player.ts`.
* Scatter 10 pieces of loot throughout the map in `src/scenes/PlayScene.ts`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nl12/pull/138?shareId=9369aae1-93b4-4777-8222-8cb527552b94).