### PR TITLE
Add loot to the map

### DIFF
--- a/src/scenes/PlayScene.ts
+++ b/src/scenes/PlayScene.ts
@@ -14,6 +14,7 @@ const Config = {
 class PlayScene extends Phaser.Scene {
 	private inputManager?: InputManager;
 	private player?: Player;
+	private lootGroup?: Phaser.Physics.Arcade.Group;
 
 	constructor() {
 		super({ key: "PlayScene" });
@@ -64,6 +65,30 @@ class PlayScene extends Phaser.Scene {
 			this,
 		);
 		this.player.setCurrentMap(tilemapManager);
+
+		this.lootGroup = this.physics.add.group({
+			allowGravity: false,
+		});
+
+		for (let i = 0; i < 10; i++) {
+			const lootPosition = tilemapManager.findRandomNonFilledTile();
+			if (lootPosition) {
+				const loot = this.physics.add.sprite(
+					lootPosition.x * Config.TileWidth,
+					lootPosition.y * Config.TileHeight,
+					"loot",
+				);
+				this.lootGroup.add(loot);
+			}
+		}
+
+		this.physics.add.overlap(
+			this.player,
+			this.lootGroup,
+			this.handlePlayerLootOverlap,
+			undefined,
+			this,
+		);
 	}
 
 	update() {
@@ -76,6 +101,10 @@ class PlayScene extends Phaser.Scene {
 
 	private handlePlayerCollision(player: any, tile: any) {
 		(player as Player).handleCollision();
+	}
+
+	private handlePlayerLootOverlap(player: any, loot: any) {
+		loot.destroy();
 	}
 }
 

--- a/src/utils/TextureManager.ts
+++ b/src/utils/TextureManager.ts
@@ -32,6 +32,16 @@ class TextureManager {
 			spacing: 0,
 			noise: true,
 		},
+		LOOT: {
+			name: "loot",
+			height: 25,
+			width: 25,
+			count: 1,
+			color: 0x00ff00,
+			margin: 0,
+			spacing: 0,
+			noise: false,
+		},
 	};
 
 	static generateTextureIfNotExists(
@@ -56,6 +66,7 @@ class TextureManager {
 		this.generateTextureIfNotExists(scene, this.Textures.PLAYER);
 		this.generateTextureIfNotExists(scene, this.Textures.EMPTY_TILE);
 		this.generateTextureIfNotExists(scene, this.Textures.FILLED_TILE);
+		this.generateTextureIfNotExists(scene, this.Textures.LOOT);
 	}
 
 	static generateTexture(


### PR DESCRIPTION
Related to #136

Add loot to the map and handle player overlap with loot items.

* Add a new `Textures` entry for LOOT colored green without noise in `src/utils/TextureManager.ts`.
* Create a physics group to hold the loot sprites in `src/scenes/PlayScene.ts`.
* Add an overlap handler to detect overlap between the player and loot items in `src/scenes/PlayScene.ts`.
* Remove the loot piece from the map when the player overlaps it in `src/scenes/PlayScene.ts`.
* Scatter 10 pieces of loot throughout the map into unfilled spaces in `src/scenes/PlayScene.ts`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nl12/pull/140?shareId=331da6ee-9d1c-4be6-968e-b424ead8837f).