### PR TITLE
Add map regeneration on 'r' key press

### DIFF
--- a/src/utils/InputManager.ts
+++ b/src/utils/InputManager.ts
@@ -6,17 +6,20 @@ type Inputs = {
 	left: boolean;
 	right: boolean;
 	grappling: boolean;
+	regenerate: boolean;
 };
 
 class InputManager {
 	private inputs: Inputs;
 	private cursors: Phaser.Types.Input.Keyboard.CursorKeys;
 	private grapplingKey: Phaser.Input.Keyboard.Key;
+	private regenerateKey: Phaser.Input.Keyboard.Key;
 
 	constructor(scene: Phaser.Scene) {
-		this.inputs = { up: false, down: false, left: false, right: false, grappling: false };
+		this.inputs = { up: false, down: false, left: false, right: false, grappling: false, regenerate: false };
 		this.cursors = scene.input.keyboard.createCursorKeys();
 		this.grapplingKey = scene.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.SHIFT);
+		this.regenerateKey = scene.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.R);
 	}
 
 	public update() {
@@ -25,6 +28,7 @@ class InputManager {
 		this.inputs.left = this.cursors.left.isDown;
 		this.inputs.right = this.cursors.right.isDown;
 		this.inputs.grappling = this.grapplingKey.isDown;
+		this.inputs.regenerate = this.regenerateKey.isDown;
 	}
 
 	public getInputs(): Inputs {


### PR DESCRIPTION
Related to #141

Add functionality to regenerate the map when the 'r' key is pressed.

* **InputManager.ts**
  - Add handling for the 'r' key input.
  - Add a new property `regenerate` to the `Inputs` type.
  - Add a new key for the 'r' key in the constructor.
  - Update the `update` method to check the state of the 'r' key.

* **PlayScene.ts**
  - Add a method `regenerateMap` to remove all filled tiles and repopulate with a new map.
  - Add logic to remove existing loot and repopulate with new loot items in `regenerateMap`.
  - Add logic to call `regenerateMap` when the 'r' key is pressed in the `update` method.
  - Update references to `tilemapManager` to use `this.tilemapManager`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nl12/pull/142?shareId=8306a78d-f2f9-4447-98e7-1b642531b68e).