### PR TITLE
Add new DEAD state to player and transition to DEAD state if any part of the player is in a filled tile

### DIFF
--- a/src/objects/Player.ts
+++ b/src/objects/Player.ts
@@ -10,6 +10,7 @@ enum PlayerState {
 	FALLING,
 	GLIDING,
 	GRAPPLING,
+	DEAD,
 }
 
 interface State {
@@ -283,6 +284,15 @@ class Player extends Phaser.Physics.Arcade.Sprite {
 			},
 			onCollision: () => {},
 		},
+		[PlayerState.DEAD]: {
+			onEnter: (inputs: Inputs) => {
+				this.getBody().setVelocity(0, 0);
+				this.setTint(0xff0000); // Set player color to red
+			},
+			onExecute: (inputs: Inputs) => {},
+			onExit: (inputs: Inputs) => {},
+			onCollision: () => {},
+		},
 	};
 
 	handleCollision() {
@@ -290,6 +300,9 @@ class Player extends Phaser.Physics.Arcade.Sprite {
 	}
 
 	public updateState(inputs: Inputs) {
+		if (this.currentMap.isInFilledTile(this.x, this.y, this.width, this.height)) {
+			this.nextState = PlayerState.DEAD;
+		}
 		if (this.nextState !== this.currentState) {
 			this.stateMachine[this.currentState].onExit(inputs);
 			this.currentState = this.nextState;
@@ -314,6 +327,8 @@ class Player extends Phaser.Physics.Arcade.Sprite {
 				return "GLIDING";
 			case PlayerState.GRAPPLING:
 				return "GRAPPLING";
+			case PlayerState.DEAD:
+				return "DEAD";
 			default:
 				return "";
 		}

--- a/src/scenes/PlayScene.ts
+++ b/src/scenes/PlayScene.ts
@@ -129,6 +129,10 @@ class PlayScene extends Phaser.Scene {
 				this.lootGroup.add(loot);
 			}
 		}
+
+		if (this.player && this.tilemapManager.isInFilledTile(this.player.x, this.player.y, this.player.width, this.player.height)) {
+			this.player.updateState({ up: false, down: false, left: false, right: false, grappling: false, regenerate: false });
+		}
 	}
 }
 

--- a/src/utils/TilemapManager.ts
+++ b/src/utils/TilemapManager.ts
@@ -139,6 +139,23 @@ class TilemapManager {
 		}
 		return null;
 	}
+
+	public isInFilledTile(x: number, y: number, width: number, height: number): boolean {
+		const topLeft = this.tilemap.getTileAtWorldXY(x, y);
+		const topRight = this.tilemap.getTileAtWorldXY(x + width, y);
+		const bottomLeft = this.tilemap.getTileAtWorldXY(x, y + height);
+		const bottomRight = this.tilemap.getTileAtWorldXY(x + width, y + height);
+
+		const filledTilesetFirstGid = this.filledTileset.firstgid;
+		const filledTilesetLastGid = this.filledTileset.firstgid + this.filledTileset.total;
+
+		return (
+			(topLeft && topLeft.index >= filledTilesetFirstGid && topLeft.index < filledTilesetLastGid) ||
+			(topRight && topRight.index >= filledTilesetFirstGid && topRight.index < filledTilesetLastGid) ||
+			(bottomLeft && bottomLeft.index >= filledTilesetFirstGid && bottomLeft.index < filledTilesetLastGid) ||
+			(bottomRight && bottomRight.index >= filledTilesetFirstGid && bottomRight.index < filledTilesetLastGid)
+		);
+	}
 }
 
 export default TilemapManager;


### PR DESCRIPTION
Related to #143

Add DEAD state to player and transition to DEAD state if any part of the player is in a filled tile.

* Add `DEAD` state to `PlayerState` enum in `src/objects/Player.ts`.
* Add `DEAD` state to `stateMachine` in `src/objects/Player.ts` with appropriate methods.
* Modify `updateState` method in `src/objects/Player.ts` to check if player is in filled tile and transition to `DEAD` state.
* Modify `regenerateMap` method in `src/scenes/PlayScene.ts` to check if player is in filled tile after regenerating the map and transition to `DEAD` state.
* Add `isInFilledTile` method in `src/utils/TilemapManager.ts` to check if a given rectangle overlaps with any filled tiles.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nl12/pull/145?shareId=2228d8bf-702e-46a0-a9b7-deb945ee691d).