### PR TITLE
Increase the map resolution

### DIFF
--- a/src/objects/Player.ts
+++ b/src/objects/Player.ts
@@ -49,7 +49,7 @@ class Player extends Phaser.Physics.Arcade.Sprite {
 			TextureManager.Textures.PLAYER,
 		);
 		this.setTexture(TextureManager.Textures.PLAYER.name);
-		this.body?.setSize(width, height);
+		this.body?.setSize(width * 2, height * 2); // P328b
 
 		this.stateText = this.scene.add.text(
 			this.x,

--- a/src/scenes/PlayScene.ts
+++ b/src/scenes/PlayScene.ts
@@ -5,10 +5,10 @@ import InputManager from "../utils/InputManager";
 import Player from "../objects/Player";
 
 const Config = {
-	MapWidth: 800 / 25,
-	MapHeight: 600 / 25,
-	TileWidth: 25,
-	TileHeight: 25,
+	MapWidth: 800 / 12,
+	MapHeight: 600 / 12,
+	TileWidth: 12,
+	TileHeight: 12,
 };
 
 class PlayScene extends Phaser.Scene {
@@ -54,8 +54,8 @@ class PlayScene extends Phaser.Scene {
 			this,
 			playerStart.x * Config.TileWidth + Config.TileWidth / 2,
 			playerStart.y * Config.TileHeight + Config.TileHeight / 2,
-			Config.TileWidth,
-			Config.TileHeight,
+			Config.TileWidth * 2,
+			Config.TileHeight * 2,
 		);
 		this.physics.add.existing(this.player);
 		this.physics.add.collider(
@@ -79,6 +79,7 @@ class PlayScene extends Phaser.Scene {
 					lootPosition.y * Config.TileHeight + Config.TileHeight / 2,
 					"loot",
 				);
+				loot.setDisplaySize(Config.TileWidth * 2, Config.TileHeight * 2);
 				this.lootGroup.add(loot);
 			}
 		}
@@ -87,7 +88,7 @@ class PlayScene extends Phaser.Scene {
 			this.player,
 			this.lootGroup,
 			this.handlePlayerLootOverlap,
-			undefined,
+				undefined,
 			this,
 		);
 	}
@@ -126,6 +127,7 @@ class PlayScene extends Phaser.Scene {
 					lootPosition.y * Config.TileHeight + Config.TileHeight / 2,
 					"loot",
 				);
+				loot.setDisplaySize(Config.TileWidth * 2, Config.TileHeight * 2);
 				this.lootGroup.add(loot);
 			}
 		}

--- a/src/utils/TextureManager.ts
+++ b/src/utils/TextureManager.ts
@@ -4,8 +4,8 @@ class TextureManager {
 	static readonly Textures = {
 		PLAYER: {
 			name: "player",
-			height: 25,
-			width: 25,
+			height: 12,
+			width: 12,
 			count: 1,
 			color: 0x0000ff,
 			margin: 0,
@@ -14,8 +14,8 @@ class TextureManager {
 		},
 		EMPTY_TILE: {
 			name: "empty",
-			height: 25,
-			width: 25,
+			height: 12,
+			width: 12,
 			count: 1,
 			color: 0x000000,
 			margin: 0,
@@ -24,8 +24,8 @@ class TextureManager {
 		},
 		FILLED_TILE: {
 			name: "filled",
-			height: 25,
-			width: 25,
+			height: 12,
+			width: 12,
 			count: 10,
 			color: 0xf0aa00,
 			margin: 0,
@@ -34,8 +34,8 @@ class TextureManager {
 		},
 		LOOT: {
 			name: "loot",
-			height: 25,
-			width: 25,
+			height: 12,
+			width: 12,
 			count: 1,
 			color: 0x00ff00,
 			margin: 0,


### PR DESCRIPTION
Related to #146

Decrease the tile width and height to 12 and increase the map width and height to maintain current dimensions.

* **PlayScene.ts**
  - Decrease `Config.TileWidth` and `Config.TileHeight` to 12.
  - Increase `Config.MapWidth` and `Config.MapHeight` to maintain current dimensions.
  - Set player size to twice the new tile size in `create` method.
  - Set loot size to twice the new tile size in `create` method.

* **Player.ts**
  - Set player size to twice the new tile size in constructor.

* **TextureManager.ts**
  - Decrease tile size to 12 in `Textures` object.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nl12/pull/147?shareId=91731362-ec5e-475d-a948-f0573b8e2cc8).