### PR TITLE
Increase the map resolution

### DIFF
--- a/src/scenes/PlayScene.ts
+++ b/src/scenes/PlayScene.ts
@@ -5,10 +5,10 @@ import InputManager from "../utils/InputManager";
 import Player from "../objects/Player";
 
 const Config = {
-	MapWidth: 800 / 25,
-	MapHeight: 600 / 25,
-	TileWidth: 25,
-	TileHeight: 25,
+	MapWidth: 800 / 12,
+	MapHeight: 600 / 12,
+	TileWidth: 12,
+	TileHeight: 12,
 };
 
 class PlayScene extends Phaser.Scene {

--- a/src/utils/TextureManager.ts
+++ b/src/utils/TextureManager.ts
@@ -4,8 +4,8 @@ class TextureManager {
 	static readonly Textures = {
 		PLAYER: {
 			name: "player",
-			height: 25,
-			width: 25,
+			height: 12,
+			width: 12,
 			count: 1,
 			color: 0x0000ff,
 			margin: 0,
@@ -14,8 +14,8 @@ class TextureManager {
 		},
 		EMPTY_TILE: {
 			name: "empty",
-			height: 25,
-			width: 25,
+			height: 12,
+			width: 12,
 			count: 1,
 			color: 0x000000,
 			margin: 0,
@@ -24,8 +24,8 @@ class TextureManager {
 		},
 		FILLED_TILE: {
 			name: "filled",
-			height: 25,
-			width: 25,
+			height: 12,
+			width: 12,
 			count: 10,
 			color: 0xf0aa00,
 			margin: 0,
@@ -34,8 +34,8 @@ class TextureManager {
 		},
 		LOOT: {
 			name: "loot",
-			height: 25,
-			width: 25,
+			height: 12,
+			width: 12,
 			count: 1,
 			color: 0x00ff00,
 			margin: 0,


### PR DESCRIPTION
Related to #146

Decrease the tile width and height to 12 and increase the map width and height to maintain the current dimensions.

* **PlayScene.ts**
  - Decrease `Config.TileWidth` and `Config.TileHeight` to 12.
  - Increase `Config.MapWidth` and `Config.MapHeight` to 800 / 12 and 600 / 12.
* **TextureManager.ts**
  - Update tile dimensions in `Textures` to 12x12 for PLAYER, EMPTY_TILE, FILLED_TILE, and LOOT.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nl12/pull/148?shareId=84d55c85-8aa1-4f62-8ebd-f0b42643e6b2).