### PR TITLE
Transition player to DEAD state if inside filled tile after map regenerates

### DIFF
--- a/src/objects/Player.ts
+++ b/src/objects/Player.ts
@@ -10,6 +10,7 @@ enum PlayerState {
 	FALLING,
 	GLIDING,
 	GRAPPLING,
+	DEAD,
 }
 
 interface State {
@@ -283,6 +284,16 @@ class Player extends Phaser.Physics.Arcade.Sprite {
 			},
 			onCollision: () => {},
 		},
+		[PlayerState.DEAD]: {
+			onEnter: (inputs: Inputs) => {
+				this.getBody().setVelocity(0, 0);
+			},
+			onExecute: (inputs: Inputs) => {
+				// Ignore all inputs
+			},
+			onExit: (inputs: Inputs) => {},
+			onCollision: () => {},
+		},
 	};
 
 	handleCollision() {
@@ -314,6 +325,8 @@ class Player extends Phaser.Physics.Arcade.Sprite {
 				return "GLIDING";
 			case PlayerState.GRAPPLING:
 				return "GRAPPLING";
+			case PlayerState.DEAD:
+				return "DEAD";
 			default:
 				return "";
 		}
@@ -332,6 +345,11 @@ class Player extends Phaser.Physics.Arcade.Sprite {
 			throw new Error("Current map is not set");
 		}
 		return this.currentMap.getFirstFilledTileAbove(this.x, this.y);
+	}
+
+	public isInsideFilledTile(): boolean {
+		const tile = this.currentMap.tilemap.getTileAtWorldXY(this.x, this.y);
+		return tile && tile.index >= this.currentMap.filledTileset.firstgid && tile.index < this.currentMap.filledTileset.firstgid + this.currentMap.filledTileset.total;
 	}
 }
 

--- a/src/scenes/PlayScene.ts
+++ b/src/scenes/PlayScene.ts
@@ -128,6 +128,10 @@ class PlayScene extends Phaser.Scene {
 				);
 				this.lootGroup.add(loot);
 			}
+			if (this.player.isInsideFilledTile()) {
+				this.player.updateState({ up: false, down: false, left: false, right: false, grappling: false, regenerate: false });
+				this.player.setState(PlayerState.DEAD);
+			}
 		}
 	}
 }


### PR DESCRIPTION
Related to #149

Add DEAD state to PlayerState enum and implement DEAD state in Player class to ignore all inputs.

* **Player.ts**
  - Add DEAD to PlayerState enum.
  - Implement DEAD state in stateMachine to ignore all inputs.
  - Add isInsideFilledTile method to check if the player's center is within a filled tile.

* **PlayScene.ts**
  - Update regenerateMap function to check if the player's center is within a filled tile.
  - Transition player to DEAD state if the player's center is within a filled tile.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nl12/pull/151?shareId=08d36d97-880e-4cef-8dce-d7d9de3115b5).