### PR TITLE
Transition player to DEAD state if inside filled tile

### DIFF
--- a/src/scenes/PlayScene.ts
+++ b/src/scenes/PlayScene.ts
@@ -97,6 +97,9 @@ class PlayScene extends Phaser.Scene {
 		const inputs = this.inputManager.getInputs();
 		if (this.player) {
 			this.player.updateState(inputs);
+			if (this.player.isPlayerInsideFilledTile()) {
+				this.player.setState(PlayerState.DEAD);
+			}
 		}
 		if (inputs.regenerate) {
 			this.regenerateMap();


### PR DESCRIPTION
Related to #149

Transition the player to the DEAD state if the player is inside a filled tile.

* Add `DEAD` to the `PlayerState` enum in `src/objects/Player.ts`.
* Add a new state to the `stateMachine` for `PlayerState.DEAD` in `src/objects/Player.ts`.
* Add a method `isPlayerInsideFilledTile` to check if the player's center is within a filled tile in `src/objects/Player.ts`.
* Update the `updateState` method to transition to `PlayerState.DEAD` if the player is inside a filled tile in `src/objects/Player.ts`.
* Update the `handleCollision` method to transition to `PlayerState.DEAD` if the player is inside a filled tile in `src/objects/Player.ts`.
* Add a call to `isPlayerInsideFilledTile` in the `update` method to check if the player is inside a filled tile in `src/scenes/PlayScene.ts`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nl12/pull/152?shareId=3dc36f32-af55-4f23-a4d8-d774441769f5).