### PR TITLE
Update the 'r' (regenerate) key logic to trigger only once per press

### DIFF
--- a/src/utils/InputManager.ts
+++ b/src/utils/InputManager.ts
@@ -28,7 +28,7 @@ class InputManager {
 		this.inputs.left = this.cursors.left.isDown;
 		this.inputs.right = this.cursors.right.isDown;
 		this.inputs.grappling = this.grapplingKey.isDown;
-		this.inputs.regenerate = this.regenerateKey.isDown;
+		this.inputs.regenerate = Phaser.Input.Keyboard.JustDown(this.regenerateKey);
 	}
 
 	public getInputs(): Inputs {


### PR DESCRIPTION
Related to #154

Modify the 'r' key logic to trigger regeneration only once per press.

* Use `Phaser.Input.Keyboard.JustDown` to detect the first press of the 'r' key in `src/utils/InputManager.ts`
* Set the `regenerate` input to `true` only once when the key is first pressed down

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nl12/pull/155?shareId=60a745f2-c73d-41f6-b76e-35a2bf6a6870).