### PR TITLE
Refactor getStateText to expect a state as a parameter and return the text

### DIFF
--- a/src/objects/Player.ts
+++ b/src/objects/Player.ts
@@ -55,7 +55,7 @@ class Player extends Phaser.Physics.Arcade.Sprite {
 		this.stateText = this.scene.add.text(
 			this.x,
 			this.y - 20,
-			this.getStateText(),
+			this.getStateText(this.currentState),
 			{
 				fontSize: "16px",
 				color: "#ffffff",
@@ -327,13 +327,13 @@ class Player extends Phaser.Physics.Arcade.Sprite {
 			this.stateMachine[this.currentState].onExit(inputs);
 			this.currentState = this.nextState;
 			this.stateMachine[this.currentState].onEnter(inputs);
-			this.stateText.setText(this.getStateText());
+			this.stateText.setText(this.getStateText(this.currentState));
 		}
 		this.stateText.setPosition(this.x, this.y);
 	}
 
-	private getStateText(): string {
-		switch (this.currentState) {
+	private getStateText(state: PlayerState): string {
+		switch (state) {
 			case PlayerState.IDLE:
 				return "IDLE";
 			case PlayerState.RUNNING:


### PR DESCRIPTION
Related to #156

Refactor `getStateText()` to accept a `PlayerState` parameter and return the corresponding text.

* Update `updateState` method to call `getStateText(this.currentState)` instead of `getStateText()`.
* Modify `getStateText()` method to take a `PlayerState` parameter and return the corresponding text based on the provided state.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nl12/pull/157?shareId=57c5136a-0819-4c70-bed6-ee6f661fb1b3).