### PR TITLE
Fix player levitation in DEAD state during map regeneration

### DIFF
--- a/src/objects/Player.ts
+++ b/src/objects/Player.ts
@@ -312,7 +312,11 @@ class Player extends Phaser.Physics.Arcade.Sprite {
 			onEnter: (inputs: Inputs) => {
 				this.getBody().setVelocity(0, 0);
 			},
-			onExecute: (inputs: Inputs) => {},
+			onExecute: (inputs: Inputs) => {
+				if (this.isPlayerInFilledTile()) {
+					this.getBody().setVelocity(0, 0);
+				}
+			},
 			onExit: (inputs: Inputs) => {},
 			onCollision: () => {},
 		},


### PR DESCRIPTION
Related to #158

Modify the `onExecute` method for the `DEAD` state in `src/objects/Player.ts` to set the x and y velocity to zero if the player is inside a filled tile.

* Add a check in the `onExecute` method to determine if the player is inside a filled tile and set the velocity to zero if true.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nl12/pull/159?shareId=04551d04-8112-4276-871f-7a09ffafcc5e).