### PR TITLE
Fix player dead state transition when regenerating map

### DIFF
--- a/src/scenes/PlayScene.ts
+++ b/src/scenes/PlayScene.ts
@@ -128,6 +128,9 @@ class PlayScene extends Phaser.Scene {
 				);
 				this.lootGroup.add(loot);
 			}
+			if (this.player && this.player.isPlayerInFilledTile()) {
+				this.player.updateState({ up: false, down: false, left: false, right: false, grappling: false, regenerate: false });
+			}
 		}
 	}
 }


### PR DESCRIPTION
Related to #160

Add a check in the `regenerateMap` method to transition the player to `DEAD` state if inside a filled tile.

* Use the `isPlayerInFilledTile` method from the `Player` class to check if the player is inside a filled tile
* Update the player's state to `DEAD` if the player is inside a filled tile after regeneration

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/abrie/nl12/pull/161?shareId=ff90273b-06d0-4d73-b608-73d30f8c8dc9).